### PR TITLE
Add onrequest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,22 @@ The default values are shown after each option key.
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
 	agent: null         // http(s).Agent instance, allows custom proxy, certificate, lookup, family etc.
+	onrequest: null     // a callback to be called with `http.ClientRequest`.
 }
 ```
+
+###### Intercepting `http.ClientRequest` with `onrequest` callback
+
+`onrequest` callback will be called with underlying `http.ClientRequest` as
+the first argument immediately before flushing. It is assured that the following
+operations on `http.ClientRequest` can be performed:
+
+* Modifying `maxHeadersCount` property to inspect or change the maximum response headers count.
+* Calling `removeHeader` and `setHeader` method to modify any headers to be sent.
+* Calling `setNoDelay`, `setSocketKeepAlive`, and `setTimeout` method, expecting the documented behavior.
+
+Other operations with side effects on `http.ClientRequest` can cause an
+unexpected behavior.
 
 ##### Default Headers
 

--- a/src/index.js
+++ b/src/index.js
@@ -202,6 +202,10 @@ export default function fetch(url, opts) {
 			resolve(new Response(body, response_options));
 		});
 
+		if (request.onrequest) {
+			request.onrequest(req);
+		}
+
 		writeToStream(req, request);
 	});
 

--- a/src/request.js
+++ b/src/request.js
@@ -98,6 +98,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.onrequest = init.onrequest || input.onrequest;
 	}
 
 	get method() {

--- a/test/test.js
+++ b/test/test.js
@@ -1513,6 +1513,18 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should call onrequest callback with an http.ClientRequest instance', function() {
+		let onrequestArgument;
+
+		return fetch('https://github.com/', {
+			onrequest(argument) {
+				onrequestArgument = argument;
+			}
+		}).then(() => {
+			expect(onrequestArgument).to.be.an.instanceof(http.ClientRequest);
+		});
+	});
+
 	// issue #414
 	it('should reject if attempt to accumulate body stream throws', function () {
 		let body = resumer().queue('a=1').end();


### PR DESCRIPTION
`onrequest` option allows to intercept `http.ClientRequest`. It is especially
useful for HTTP Signatures or similar authentication mechanism which
require exact HTTP header representation.

This change is radical as you can see. Let me know if you prefer an alternative.