### PR TITLE
fix: allow any EventTarget as AbortSignal (#692)

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -33,13 +33,11 @@ function isRequest(input) {
 	);
 }
 
-function isAbortSignal(signal) {
-	const proto = (
-		signal
-		&& typeof signal === 'object'
-		&& Object.getPrototypeOf(signal)
-	);
-	return !!(proto && proto.constructor.name === 'AbortSignal');
+function isEventTarget(signal) {
+	return signal 
+		&& typeof signal === 'object' 
+		&& typeof signal.addEventListener == 'function' 
+		&& typeof signal.removeEventListener == 'function';
 }
 
 /**
@@ -102,8 +100,8 @@ export default class Request {
 			: null;
 		if ('signal' in init) signal = init.signal
 
-		if (signal != null && !isAbortSignal(signal)) {
-			throw new TypeError('Expected signal to be an instanceof AbortSignal');
+		if (signal != null && !isEventTarget(signal)) {
+			throw new TypeError('Expected signal to be an instanceof EventTarget');
 		}
 
 		this[INTERNALS] = {

--- a/test/test.js
+++ b/test/test.js
@@ -1069,21 +1069,26 @@ describe('node-fetch', () => {
 			.and.have.property('message').includes('not supported');
 	});
 
-	it('should throw a TypeError if a signal is not of type AbortSignal', () => {
+	it('should throw a TypeError if a signal is not of type EventTarget', () => {
 		return Promise.all([
 			expect(fetch(`${base}inspect`, { signal: {} }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
-				.and.have.property('message').includes('AbortSignal'),
+				.and.have.property('message').includes('EventTarget'),
 			expect(fetch(`${base}inspect`, { signal: '' }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
-				.and.have.property('message').includes('AbortSignal'),
+				.and.have.property('message').includes('EventTarget'),
 			expect(fetch(`${base}inspect`, { signal: Object.create(null) }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
-				.and.have.property('message').includes('AbortSignal'),
+				.and.have.property('message').includes('EventTarget'),
 		]);
+	});
+
+	it('accepts a custom EventTarget implementation as a signal if all used methods are implemented', () => {
+		expect(fetch(`${base}inspect`, { signal: Object.create({ addEventListener: () => {}, removeEventListener: () => {} }) }))
+			.to.be.eventually.resolved
 	});
 
 	it('should set default User-Agent', function () {


### PR DESCRIPTION
Fixes #692 by only checking that the required signal methods are implemented.

This should also allow different AbortController implementations or Proxys to work successfully.