### PR TITLE
fix: requestOptions should conform to the http(s).request interface

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -260,15 +260,10 @@ export function getNodeRequestOptions(request) {
 
 	// manually spread the URL object instead of spread syntax
 	const requestOptions = {
-		path: parsedURL.pathname,
-		pathname: parsedURL.pathname,
+		path: `${parsedURL.pathname}${parsedURL.search}`,
 		hostname: parsedURL.hostname,
 		protocol: parsedURL.protocol,
 		port: parsedURL.port,
-		hash: parsedURL.hash,
-		search: parsedURL.search,
-		query: parsedURL.query,
-		href: parsedURL.href,
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
 		agent

--- a/test/main.js
+++ b/test/main.js
@@ -1468,6 +1468,15 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should preserve search params in the url', () => {
+		const url = `${base}inspect?foo=bar`;
+		return fetch(url).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.url).to.equal('/inspect?foo=bar');
+		});
+	});
+
 	it('should allow POST request with URLSearchParams as body', () => {
 		const parameters = new URLSearchParams();
 		parameters.append('a', '1');

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -329,7 +329,7 @@ export default class TestServer {
 			res.end();
 		}
 
-		if (p === '/inspect') {
+		if (p.startsWith('/inspect')) {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');
 			let body = '';


### PR DESCRIPTION
The requestOptions being returned did not conform to the options
interface expected by node's request function. Specifically, the path
option must include the pathname and search properties from a URL
instance, host is ignored when hostname is present, and the following
are not recognized: hash, search, query, href

fixes #749 