### PR TITLE
Settle `consumeBody` promise when the response closes prematurely

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -595,6 +595,16 @@ describe('node-fetch', () => {
 			.and.have.property('code', 'ECONNRESET');
 	});
 
+	it('should handle network-error partial response', () => {
+		const url = `${base}error/premature`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+			return expect(res.text()).to.eventually.be.rejectedWith(Error)
+				.and.have.property('message').includes('Premature close');
+		});
+	});
+
 	it('should handle DNS-error response', () => {
 		const url = 'http://domain.invalid';
 		return expect(fetch(url)).to.eventually.be.rejected

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -302,6 +302,14 @@ export default class TestServer {
 			res.destroy();
 		}
 
+		if (p === '/error/premature') {
+			res.writeHead(200, {'content-length': 50});
+			res.write('foo');
+			setTimeout(() => {
+				res.destroy();
+			}, 100);
+		}
+
 		if (p === '/error/json') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
👋 Hi, the newly added test demonstrates that the `consumeBody` promise would never settle if the body stream was closed prematurely by the server.

---------

### fix: consumeBody promise should settle when the response closes prematurely

The stream.finished function is used consolidate the terminal cases.
The writable option must be set to false, since the body stream is
a Duplex stream, but our terminal cases only apply to the Readable side.