### PR TITLE
fix: Disambiguate timeout behavior for response headers and body

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -200,7 +200,9 @@ function consumeBody() {
 		if (this.timeout) {
 			resTimeout = setTimeout(() => {
 				abort = true;
-				reject(new FetchError(`Response timeout while trying to fetch ${this.url} (over ${this.timeout}ms)`, 'body-timeout'));
+				const err = new FetchError(`Response timeout while trying to fetch ${this.url} (over ${this.timeout}ms)`, 'body-timeout');
+				reject(err);
+				body.destroy(err);
 			}, this.timeout);
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,7 @@ export default function fetch(url, options_) {
 		});
 
 		request_.on('response', res => {
+			request_.setTimeout(0);
 			const headers = createHeadersLenient(res.headers);
 
 			// HTTP fetch step 5

--- a/test/utils/delay.js
+++ b/test/utils/delay.js
@@ -1,0 +1,7 @@
+export default function delay(ms) {
+	return value => new Promise(resolve => {
+		setTimeout(() => {
+			resolve(value);
+		}, ms);
+	});
+}


### PR DESCRIPTION
There is a single timeout option which applies to both the receiving of
response headers and the receiving of the entire response body. Once
the response is received, the socket timeout must be cleared to allow
the timeout to apply to the receiving of the entire response body.

Without clearing the socket timeout, if the nearing the idle timeout
when the Promise for the body is created, then the request's timeout
handler will abort the request, emitting ERR_STREAM_PREMATURE_CLOSE in
the body Promise.

By clearing the socket timeout once the response headers are received,
the timeout for the entire body can be started when the body is awaited.
Since the request will no longer be aborted by the socket timeout,
destroy is called on the body to prevent it continuing to emit data
events.

--------

Picked from #768 