### PR TITLE
Allow passing BODY in GET request via configurable Parameter in OPTIO…

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -82,15 +82,15 @@ export default class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
-		let checkBodyllowedInGET = false;
+		let allowBody = false;
 		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true) ||
 			(isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)) {
-			checkBodyllowedInGET = true;
+			allowBody = true;
 		}
 
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null || isRequest(input) && input.body !== null) &&
-			(method === 'GET' && checkBodyllowedInGET === false || method === 'HEAD')) {
+			(method === 'GET' && allowBody === false || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}
 

--- a/src/request.js
+++ b/src/request.js
@@ -83,7 +83,7 @@ export default class Request {
 		method = method.toUpperCase();
 
 		let overrideGetBodyCheck = false;
-		// eslint-disable-next-line no-eq-null
+		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null && init.allowBody === true) ||
 			(isRequest(input) && input.body !== null && input.allowBody === true)) {
 			overrideGetBodyCheck = true;

--- a/src/request.js
+++ b/src/request.js
@@ -82,15 +82,16 @@ export default class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
-		let allowBody = false;
-		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true) ||
-			(isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)) {
-			allowBody = true;
+		let overrideGetBodyCheck = false;
+		// eslint-disable-next-line no-eq-null
+		if ((init.body != null && init.allowBody === true) ||
+			(isRequest(input) && input.body !== null && input.allowBody === true)) {
+			overrideGetBodyCheck = true;
 		}
 
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null || isRequest(input) && input.body !== null) &&
-			(method === 'GET' && allowBody === false || method === 'HEAD')) {
+			(method === 'GET' && overrideGetBodyCheck === false || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}
 

--- a/src/request.js
+++ b/src/request.js
@@ -82,9 +82,18 @@ export default class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
+		
+		let checkBodyllowedInGET = false;
+		// eslint-disable-next-line no-eq-null, eqeqeq
+		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true)
+			|| (isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)){
+		  checkBodyllowedInGET = true;		
+		}
+		
+		
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null || isRequest(input) && input.body !== null) &&
-			(method === 'GET' || method === 'HEAD')) {
+			(method === 'GET' && checkBodyllowedInGET === false || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}
 

--- a/src/request.js
+++ b/src/request.js
@@ -85,7 +85,7 @@ export default class Request {
 		let checkBodyllowedInGET = false;
 		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true) ||
 			(isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)) {
-			checkBodyllowedInGET = true;		
+			checkBodyllowedInGET = true;
 		}
 
 		// eslint-disable-next-line no-eq-null, eqeqeq

--- a/src/request.js
+++ b/src/request.js
@@ -82,15 +82,12 @@ export default class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
-		
 		let checkBodyllowedInGET = false;
-		// eslint-disable-next-line no-eq-null, eqeqeq
-		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true)
-			|| (isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)){
-		  checkBodyllowedInGET = true;		
+		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true) ||
+			(isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)) {
+			checkBodyllowedInGET = true;		
 		}
-		
-		
+
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null || isRequest(input) && input.body !== null) &&
 			(method === 'GET' && checkBodyllowedInGET === false || method === 'HEAD')) {


### PR DESCRIPTION
…NS, defaulted to ERROR

Add configurable Parameter overrideGetBodyCheck, if set to true in OPTIONS, then it would bypass Error check for the Request "Body" in the GET request. It would allow the request if the parameter is set to true, otherwise, it would reject the GET requests with the BODY.