### PR TITLE
chore: http2 support (WIP)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -174,6 +174,8 @@ export class Response extends Body {
 	url: string;
 	size: number;
 	timeout: number;
+	highWaterMark: number;
+	httpVersion: string;
 	constructor(body?: BodyInit, init?: ResponseInit);
 	static error(): Response;
 	static redirect(url: string, status: number): Response;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
 	},
 	"dependencies": {
 		"data-uri-to-buffer": "^3.0.0",
-		"fetch-blob": "^1.0.5"
+		"fetch-blob": "^1.0.5",
+		"http2-client": "^1.3.3"
 	},
 	"xo": {
 		"envs": [

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@
  */
 
 import http from 'http';
-import https from 'https';
+import {request as http2} from 'http2-client';
 import zlib from 'zlib';
 import Stream, {PassThrough, pipeline as pump} from 'stream';
 import dataURIToBuffer from 'data-uri-to-buffer';
@@ -56,7 +56,8 @@ export default function fetch(url, options_) {
 		const request = new Request(url, options_);
 		const options = getNodeRequestOptions(request);
 
-		const send = (options.protocol === 'https:' ? https : http).request;
+		const send = (options.protocol === 'https:' ? http2 : http.request);
+
 		const {signal} = request;
 		let response = null;
 
@@ -211,6 +212,7 @@ export default function fetch(url, options_) {
 				size: request.size,
 				timeout: request.timeout,
 				counter: request.counter,
+				httpVersion: res.httpVersion,
 				highWaterMark: request.highWaterMark
 			};
 

--- a/src/response.js
+++ b/src/response.js
@@ -36,6 +36,7 @@ export default class Response {
 			statusText: options.statusText || '',
 			headers,
 			counter: options.counter,
+			httpVersion: options.httpVersion,
 			highWaterMark: options.highWaterMark
 		};
 	}
@@ -65,6 +66,10 @@ export default class Response {
 
 	get headers() {
 		return this[INTERNALS].headers;
+	}
+
+	get httpVersion() {
+		return this[INTERNALS].httpVersion;
 	}
 
 	get highWaterMark() {

--- a/test/main.js
+++ b/test/main.js
@@ -2040,13 +2040,22 @@ describe('node-fetch', () => {
 
 	it('should support https request', function () {
 		this.timeout(5000);
-		const url = 'https://github.com/';
+		const url = 'https://github.com';
 		const options = {
 			method: 'HEAD'
 		};
 		return fetch(url, options).then(res => {
 			expect(res.status).to.equal(200);
 			expect(res.ok).to.be.true;
+		});
+	});
+
+	it('http2', function () {
+		this.timeout(5000);
+		const url = 'https://http2.golang.org/';
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.httpVersion).to.equal('2.0');
 		});
 	});
 

--- a/test/main.js
+++ b/test/main.js
@@ -2050,8 +2050,7 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('http2', function () {
-		this.timeout(5000);
+	it('http2', () => {
 		const url = 'https://http2.golang.org/';
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);

--- a/test/main.js
+++ b/test/main.js
@@ -2050,7 +2050,8 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('http2', () => {
+	it('http2', function () {
+		this.timeout(5000);
 		const url = 'https://http2.golang.org/';
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);


### PR DESCRIPTION
**Do not merge yet!**

Fixes #342

---

I've decided to try and implement http2 support in node-fetch. I ended up using the `http2-client` module, which makes it easy to support `https/1.1` and `http/2.0` protocols without doing any changes at all.

The current implementation does not support unencrypted http2, due to test issues.

Now, I'm not sure whether this approach is correct. I will try to experiment more in the upcoming days.