### PR TITLE
Add Brotli support in Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ If no values are set, the following request headers will be sent automatically:
 
 | Header              | Value                                                    |
 | ------------------- | -------------------------------------------------------- |
-| `Accept-Encoding`   | `gzip,deflate` _(when `options.compress === true`)_      |
+| `Accept-Encoding`   | `gzip,deflate,br` _(when `options.compress === true`)_   |
 | `Accept`            | `*/*`                                                    |
 | `Connection`        | `close` _(when no `options.agent` is present)_           |
 | `Content-Length`    | _(automatically calculated, if possible)_                |
@@ -696,9 +696,9 @@ Thanks to [github/fetch](https://github.com/github/fetch) for providing a solid 
 
 ## Team
 
-[![David Frank](https://github.com/bitinn.png?size=100)](https://github.com/bitinn) | [![Jimmy Wärting](https://github.com/jimmywarting.png?size=100)](https://github.com/jimmywarting) | [![Antoni Kepinski](https://github.com/xxczaki.png?size=100)](https://github.com/xxczaki) | [![Richie Bendall](https://github.com/Richienb.png?size=100)](https://github.com/Richienb) | [![Gregor Martynus](https://github.com/gr2m.png?size=100)](https://github.com/gr2m)
----|---|---|---|---
-[David Frank](https://bitinn.net/) | [Jimmy Wärting](https://jimmy.warting.se/) | [Antoni Kepinski](https://kepinski.me) | [Richie Bendall](https://www.richie-bendall.ml/) | [Gregor Martynus](https://twitter.com/gr2m)
+| [![David Frank](https://github.com/bitinn.png?size=100)](https://github.com/bitinn) | [![Jimmy Wärting](https://github.com/jimmywarting.png?size=100)](https://github.com/jimmywarting) | [![Antoni Kepinski](https://github.com/xxczaki.png?size=100)](https://github.com/xxczaki) | [![Richie Bendall](https://github.com/Richienb.png?size=100)](https://github.com/Richienb) | [![Gregor Martynus](https://github.com/gr2m.png?size=100)](https://github.com/gr2m) |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| [David Frank](https://bitinn.net/)                                                  | [Jimmy Wärting](https://jimmy.warting.se/)                                                        | [Antoni Kepinski](https://kepinski.me)                                                    | [Richie Bendall](https://www.richie-bendall.ml/)                                           | [Gregor Martynus](https://twitter.com/gr2m)                                         |
 
 ###### Former
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 **Work in progress!**
 
+- **Breaking:** minimum supported Node.js version is now 10.16.
 - Enhance: improve coverage.
 - Enhance: drop Babel (while keeping ESM) (#805).
 - Fix: export the `AbortError` class.

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -19,7 +19,7 @@ other comparatively minor modifications.
 
 # Breaking Changes
 
-## Minimum supported Node.js version is now 10
+## Minimum supported Node.js version is now 10.16
 
 Since Node.js will deprecate version 8 at the end of 2019, we decided that node-fetch v3.x will not only drop support for Node.js 4 and 6 (which were supported in v2.x), but also for Node.js 8. We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"*.d.ts"
 	],
 	"engines": {
-		"node": ">=10"
+		"node": ">=10.16"
 	},
 	"scripts": {
 		"build": "rollup -c",

--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,7 @@ export default function fetch(url, options_) {
 			}
 
 			// For br
-			if (codings === 'br' && typeof zlib.createBrotliDecompress === 'function') {
+			if (codings === 'br') {
 				body = pump(body, zlib.createBrotliDecompress(), error => {
 					reject(error);
 				});

--- a/src/request.js
+++ b/src/request.js
@@ -239,7 +239,7 @@ export function getNodeRequestOptions(request) {
 
 	// HTTP-network-or-cache fetch step 2.15
 	if (request.compress && !headers.has('Accept-Encoding')) {
-		headers.set('Accept-Encoding', 'gzip,deflate');
+		headers.set('Accept-Encoding', 'gzip,deflate,br');
 	}
 
 	let {agent} = request;


### PR DESCRIPTION
Brotli is supported in Node.JS core since version 10.16 and it was handled in `node-fetch` under the guard on receiving, however it wasn't set on request. This PR fixes and documents that support.