### PR TITLE
Move `isRedirect` function to a seperate file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,14 @@ import Headers, {createHeadersLenient} from './headers.js';
 import Request, {getNodeRequestOptions} from './request.js';
 import FetchError from './errors/fetch-error.js';
 import AbortError from './errors/abort-error.js';
+import {isRedirect} from './utils/is-redirect.js';
 
 export {default as Headers} from './headers.js';
 export {default as Request} from './request.js';
 export {default as Response} from './response.js';
 export {default as FetchError} from './errors/fetch-error.js';
 export {default as AbortError} from './errors/abort-error.js';
+export {isRedirect};
 
 /**
  * Fetch function
@@ -121,7 +123,7 @@ export default function fetch(url, options_) {
 			const headers = createHeadersLenient(res.headers);
 
 			// HTTP fetch step 5
-			if (fetch.isRedirect(res.statusCode)) {
+			if (isRedirect(res.statusCode)) {
 				// HTTP fetch step 5.2
 				const location = headers.get('Location');
 
@@ -301,14 +303,6 @@ export default function fetch(url, options_) {
 		writeToStream(request_, request);
 	});
 }
-
-/**
- * Redirect code matching
- *
- * @param   Number   code  Status code
- * @return  Boolean
- */
-fetch.isRedirect = code => [301, 302, 303, 307, 308].includes(code);
 
 // Expose Promise
 fetch.Promise = global.Promise;

--- a/src/response.js
+++ b/src/response.js
@@ -6,6 +6,7 @@
 
 import Headers from './headers.js';
 import Body, {clone, extractContentType} from './body.js';
+import {isRedirect} from './utils/is-redirect.js';
 
 const INTERNALS = Symbol('Response internals');
 
@@ -95,7 +96,7 @@ export default class Response {
 	 * @returns {Response}    A Response object.
 	 */
 	static redirect(url, status = 302) {
-		if (![301, 302, 303, 307, 308].includes(status)) {
+		if (!isRedirect(status)) {
 			throw new RangeError('Failed to execute "redirect" on "response": Invalid status code');
 		}
 

--- a/src/utils/is-redirect.js
+++ b/src/utils/is-redirect.js
@@ -1,0 +1,12 @@
+// https://onlinewritingtraining.com.au/plural-of-status/
+const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Redirect code matching
+ *
+ * @param {number} code - Status code
+ * @return {boolean}
+ */
+export function isRedirect(code) {
+	return REDIRECT_STATUS.has(code);
+}

--- a/src/utils/is-redirect.js
+++ b/src/utils/is-redirect.js
@@ -1,5 +1,4 @@
-// https://onlinewritingtraining.com.au/plural-of-status/
-const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
+const redirectStatus = new Set([301, 302, 303, 307, 308]);
 
 /**
  * Redirect code matching
@@ -8,5 +7,5 @@ const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
  * @return {boolean}
  */
 export function isRedirect(code) {
-	return REDIRECT_STATUS.has(code);
+	return redirectStatus.has(code);
 }


### PR DESCRIPTION
- Fixes `isRedirect` hackish "export" as property on default export to be a real ES6 named export
- Replace array creation and iteration on each call with static O(1) Set
- Reuse `isRedirect` at `Response` class