### PR TITLE
Use built-in method for `isArrayBuffer`

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -6,10 +6,11 @@
  */
 
 import Stream, {PassThrough} from 'stream';
+import {types} from 'util';
 
 import Blob from 'fetch-blob';
 import FetchError from './errors/fetch-error.js';
-import {isBlob, isURLSearchParams, isArrayBuffer, isAbortError} from './utils/is.js';
+import {isBlob, isURLSearchParams, isAbortError} from './utils/is.js';
 
 const INTERNALS = Symbol('Body internals');
 
@@ -36,7 +37,7 @@ export default function Body(body, {
 		// Body is blob
 	} else if (Buffer.isBuffer(body)) {
 		// Body is Buffer
-	} else if (isArrayBuffer(body)) {
+	} else if (types.isAnyArrayBuffer(body)) {
 		// Body is ArrayBuffer
 		body = Buffer.from(body);
 	} else if (ArrayBuffer.isView(body)) {
@@ -315,7 +316,7 @@ export function extractContentType(body) {
 	}
 
 	// Body is a Buffer (Buffer, ArrayBuffer or ArrayBufferView)
-	if (Buffer.isBuffer(body) || isArrayBuffer(body) || ArrayBuffer.isView(body)) {
+	if (Buffer.isBuffer(body) || types.isAnyArrayBuffer(body) || ArrayBuffer.isView(body)) {
 		return null;
 	}
 

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -58,16 +58,6 @@ export function isAbortSignal(object) {
 }
 
 /**
- * Check if `obj` is an instance of ArrayBuffer.
- *
- * @param  {*} obj
- * @return {boolean}
- */
-export function isArrayBuffer(object) {
-	return object[NAME] === 'ArrayBuffer';
-}
-
-/**
  * Check if `obj` is an instance of AbortError.
  *
  * @param  {*} obj


### PR DESCRIPTION
Replaces custom implementation of `isArrayBuffer` in favor of `util.types.isAnyArrayBuffer` available since Node 10.0