### PR TITLE
Normalize `export` syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,7 @@ import FetchError from './errors/fetch-error.js';
 import AbortError from './errors/abort-error.js';
 import {isRedirect} from './utils/is-redirect.js';
 
-export {default as Headers} from './headers.js';
-export {default as Request} from './request.js';
-export {default as Response} from './response.js';
-export {default as FetchError} from './errors/fetch-error.js';
-export {default as AbortError} from './errors/abort-error.js';
-export {isRedirect};
+export {Headers, Request, Response, FetchError, AbortError, isRedirect};
 
 /**
  * Fetch function


### PR DESCRIPTION
**What is the purpose of this pull request?**

Normalizes `export` syntax in index.js