### PR TITLE
Use normal class inheritance instead of Body.mixIn

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -23,60 +23,60 @@ const INTERNALS = Symbol('Body internals');
  * @param   Object  opts  Response options
  * @return  Void
  */
-export default function Body(body, {
-	size = 0,
-	timeout = 0
-} = {}) {
-	if (body === null) {
+export default class Body {
+	constructor(body, {
+		size = 0,
+		timeout = 0
+	} = {}) {
+		if (body === null) {
 		// Body is undefined or null
-		body = null;
-	} else if (isURLSearchParams(body)) {
+			body = null;
+		} else if (isURLSearchParams(body)) {
 		// Body is a URLSearchParams
-		body = Buffer.from(body.toString());
-	} else if (isBlob(body)) {
+			body = Buffer.from(body.toString());
+		} else if (isBlob(body)) {
 		// Body is blob
-	} else if (Buffer.isBuffer(body)) {
+		} else if (Buffer.isBuffer(body)) {
 		// Body is Buffer
-	} else if (types.isAnyArrayBuffer(body)) {
+		} else if (types.isAnyArrayBuffer(body)) {
 		// Body is ArrayBuffer
-		body = Buffer.from(body);
-	} else if (ArrayBuffer.isView(body)) {
+			body = Buffer.from(body);
+		} else if (ArrayBuffer.isView(body)) {
 		// Body is ArrayBufferView
-		body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
-	} else if (body instanceof Stream) {
+			body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+		} else if (body instanceof Stream) {
 		// Body is stream
-	} else {
+		} else {
 		// None of the above
 		// coerce to string then buffer
-		body = Buffer.from(String(body));
+			body = Buffer.from(String(body));
+		}
+
+		this[INTERNALS] = {
+			body,
+			disturbed: false,
+			error: null
+		};
+		this.size = size;
+		this.timeout = timeout;
+
+		if (body instanceof Stream) {
+			body.on('error', err => {
+				const error = isAbortError(err) ?
+					err :
+					new FetchError(`Invalid response body while trying to fetch ${this.url}: ${err.message}`, 'system', err);
+				this[INTERNALS].error = error;
+			});
+		}
 	}
 
-	this[INTERNALS] = {
-		body,
-		disturbed: false,
-		error: null
-	};
-	this.size = size;
-	this.timeout = timeout;
-
-	if (body instanceof Stream) {
-		body.on('error', err => {
-			const error = isAbortError(err) ?
-				err :
-				new FetchError(`Invalid response body while trying to fetch ${this.url}: ${err.message}`, 'system', err);
-			this[INTERNALS].error = error;
-		});
-	}
-}
-
-Body.prototype = {
 	get body() {
 		return this[INTERNALS].body;
-	},
+	}
 
 	get bodyUsed() {
 		return this[INTERNALS].disturbed;
-	},
+	}
 
 	/**
 	 * Decode response as ArrayBuffer
@@ -85,7 +85,7 @@ Body.prototype = {
 	 */
 	arrayBuffer() {
 		return consumeBody.call(this).then(({buffer, byteOffset, byteLength}) => buffer.slice(byteOffset, byteOffset + byteLength));
-	},
+	}
 
 	/**
 	 * Return raw response as Blob
@@ -98,7 +98,7 @@ Body.prototype = {
 			type: ct.toLowerCase(),
 			buffer: buf
 		}));
-	},
+	}
 
 	/**
 	 * Decode response as json
@@ -107,7 +107,7 @@ Body.prototype = {
 	 */
 	json() {
 		return consumeBody.call(this).then(buffer => JSON.parse(buffer.toString()));
-	},
+	}
 
 	/**
 	 * Decode response as text
@@ -116,7 +116,7 @@ Body.prototype = {
 	 */
 	text() {
 		return consumeBody.call(this).then(buffer => buffer.toString());
-	},
+	}
 
 	/**
 	 * Decode response as buffer (non-spec api)
@@ -126,7 +126,7 @@ Body.prototype = {
 	buffer() {
 		return consumeBody.call(this);
 	}
-};
+}
 
 // In browsers, all properties are enumerable.
 Object.defineProperties(Body.prototype, {
@@ -137,16 +137,6 @@ Object.defineProperties(Body.prototype, {
 	json: {enumerable: true},
 	text: {enumerable: true}
 });
-
-Body.mixIn = proto => {
-	for (const name of Object.getOwnPropertyNames(Body.prototype)) {
-		// istanbul ignore else: future proof
-		if (!Object.prototype.hasOwnProperty.call(proto, name)) {
-			const desc = Object.getOwnPropertyDescriptor(Body.prototype, name);
-			Object.defineProperty(proto, name, desc);
-		}
-	}
-};
 
 /**
  * Consume and convert an entire Body to a Buffer.

--- a/src/request.js
+++ b/src/request.js
@@ -55,7 +55,7 @@ function parseURL(urlString) {
  * @param   Object  init   Custom options
  * @return  Void
  */
-export default class Request {
+export default class Request extends Body {
 	constructor(input, init = {}) {
 		let parsedURL;
 
@@ -92,7 +92,7 @@ export default class Request {
 				clone(input) :
 				null);
 
-		Body.call(this, inputBody, {
+		super(inputBody, {
 			timeout: init.timeout || input.timeout || 0,
 			size: init.size || input.size || 0
 		});
@@ -165,16 +165,11 @@ export default class Request {
 	clone() {
 		return new Request(this);
 	}
+
+	get [Symbol.toStringTag]() {
+		return 'Request';
+	}
 }
-
-Body.mixIn(Request.prototype);
-
-Object.defineProperty(Request.prototype, Symbol.toStringTag, {
-	value: 'Request',
-	writable: false,
-	enumerable: false,
-	configurable: true
-});
 
 Object.defineProperties(Request.prototype, {
 	method: {enumerable: true},

--- a/src/response.js
+++ b/src/response.js
@@ -17,9 +17,9 @@ const INTERNALS = Symbol('Response internals');
  * @param   Object  opts  Response options
  * @return  Void
  */
-export default class Response {
+export default class Response extends Body {
 	constructor(body = null, options = {}) {
-		Body.call(this, body, options);
+		super(body, options);
 
 		const status = options.status || 200;
 		const headers = new Headers(options.headers);
@@ -107,9 +107,11 @@ export default class Response {
 			status
 		});
 	}
-}
 
-Body.mixIn(Response.prototype);
+	get [Symbol.toStringTag]() {
+		return 'Response';
+	}
+}
 
 Object.defineProperties(Response.prototype, {
 	url: {enumerable: true},
@@ -121,9 +123,3 @@ Object.defineProperties(Response.prototype, {
 	clone: {enumerable: true}
 });
 
-Object.defineProperty(Response.prototype, Symbol.toStringTag, {
-	value: 'Response',
-	writable: false,
-	enumerable: false,
-	configurable: true
-});


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

I'm sure there is a reason behind the original decision to use `Body.mixIn` instead of normal class inheritance, but this reason is not reflected in current tests (as they all are passing after this refactoring).

On the other hand, using normal class inheritance, first of all, makes code easier to understand, and also works way better with static code analyzing based tooling, like IntelliSense in Visual Studio Code. It also will help if the team will decide to switch to a TypeScript one day, etc.

By the end, it's just the standard language construction for this use case.

It also will be required step to my approach to have this project typings automatically generated by TypeScript out of JSDoc, that's currently impossible due to `Body.mixIn` use.
