### PR TITLE
Test CommonJS build artifact

### DIFF
--- a/.github/workflows/commonjs.yml
+++ b/.github/workflows/commonjs.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - src/**.js
+      - package.json
+      - test/commonjs/**
+      - rollup.config.js
+      - .github/workflows/commonjs.yml
+
+jobs:
+  commonjs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json | sed 's/[^0-9.]//g')
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{steps.get-versions.outputs.node}}
+
+      - run: npm install
+
+      - run: npm run prepublishOnly

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"test": "node --experimental-modules node_modules/c8/bin/c8 --reporter=html --reporter=lcov --reporter=text --check-coverage node --experimental-modules node_modules/mocha/bin/mocha",
 		"coverage": "c8 report --reporter=text-lcov | coveralls",
 		"test-types": "tsd",
-		"lint": "xo"
+		"lint": "xo",
+		"prepublishOnly": "node ./test/commonjs/test-artifact.js"
 	},
 	"repository": {
 		"type": "git",

--- a/test/commonjs/package.json
+++ b/test/commonjs/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "commonjs",
+	"version": "1.0.0",
+	"main": "../../dist/index.cjs",
+	"type": "commonjs"
+}

--- a/test/commonjs/package.json
+++ b/test/commonjs/package.json
@@ -1,6 +1,3 @@
 {
-	"name": "commonjs",
-	"version": "1.0.0",
-	"main": "../../dist/index.cjs",
 	"type": "commonjs"
 }

--- a/test/commonjs/test-artifact.js
+++ b/test/commonjs/test-artifact.js
@@ -1,0 +1,41 @@
+// @ts-nocheck
+/**
+ * Rebuild first
+ */
+const {execFileSync} = require('child_process');
+
+console.log('Building CommonJS version...');
+execFileSync('npm', ['run', 'build'], {stdio: 'inherit'});
+
+const assert = require('assert');
+const fetch = require('./');
+assert.strictEqual(
+	typeof fetch,
+	'function',
+	'default import must be a function'
+);
+
+const {Request, Response, Headers, FetchError, AbortError} = require('./');
+assert.ok(new FetchError() instanceof Error, 'FetchError must be an Error');
+assert.ok(
+	new AbortError() instanceof Error,
+	'AbortError must be an extension of Error'
+);
+assert.ok(
+	new Request('https://www.test.com').headers instanceof Headers,
+	'Request class is not exposing correct functionality'
+);
+assert.strictEqual(
+	new Response(null, {headers: {a: 'a'}}).headers.get('a'),
+	'a',
+	'Response class is not exposing correct functionality'
+);
+
+fetch(
+	`data:text/plain;base64,${Buffer.from('Hello World!').toString('base64')}`
+)
+	.then(res => res.text())
+	.then(text => assert.strictEqual(text, 'Hello World!'))
+	.then(() => {
+		console.info('✅ CommonJS build artefact fitness testes successfully');
+	});

--- a/test/commonjs/test-artifact.js
+++ b/test/commonjs/test-artifact.js
@@ -8,14 +8,14 @@ console.log('Building CommonJS version...');
 execFileSync('npm', ['run', 'build'], {stdio: 'inherit'});
 
 const assert = require('assert');
-const fetch = require('./');
+const fetch = require('../../');
 assert.strictEqual(
 	typeof fetch,
 	'function',
 	'default import must be a function'
 );
 
-const {Request, Response, Headers, FetchError, AbortError} = require('./');
+const {Request, Response, Headers, FetchError, AbortError} = require('../../');
 assert.ok(new FetchError() instanceof Error, 'FetchError must be an Error');
 assert.ok(
 	new AbortError() instanceof Error,


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix
- [x] Other, please explain:

**What changes did you make? (provide an overview)**

These changes add a script that builds and tests the fitness of CommonJS build artifact at `prepublishOnly` command.
Should prevent incidents like #836 

Comes with GitHub Action watchdog for build-related files
