### PR TITLE
fix: improve TypeScript types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -6,7 +6,7 @@ import {Agent} from 'http';
 import * as Blob from 'fetch-blob';
 
 export type AbortSignal = {
-	readonly aborted: boolean;
+    readonly aborted: boolean;
 
     addEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { passive?: boolean; once?: boolean; }): void;
     removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -12,7 +12,7 @@ export type AbortSignal = {
     removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;
 };
 
-export type HeadersInit = Headers | string[][] | Record<string, string>;
+export type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>;
 
 /**
  * This Fetch API interface allows you to perform various actions on HTTP request and response headers.

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -5,14 +5,14 @@
 import {Agent} from 'http';
 import * as Blob from 'fetch-blob';
 
-export type AbortSignal = {
-    readonly aborted: boolean;
+type AbortSignal = {
+	readonly aborted: boolean;
 
-    addEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { passive?: boolean; once?: boolean; }): void;
-    removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;
+	addEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { passive?: boolean; once?: boolean; }): void;
+	removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;
 };
 
-export type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>;
+type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>;
 
 /**
  * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
@@ -21,7 +21,7 @@ export type HeadersInit = Headers | Record<string, string> | Iterable<readonly [
  * You can add to this using methods like append() (see Examples.)
  * In all methods of this interface, header names are matched by case-insensitive byte sequence.
  * */
-export class Headers {
+declare class Headers {
 	constructor(init?: HeadersInit);
 
 	append(name: string, value: string): void;
@@ -52,7 +52,7 @@ export class Headers {
 	raw(): Record<string, string[]>;
 }
 
-export interface RequestInit {
+interface RequestInit {
 	/**
 	 * A BodyInit object or null to set request's body.
 	 */
@@ -86,19 +86,22 @@ export interface RequestInit {
 	highWaterMark?: number;
 }
 
-export interface ResponseInit {
+interface ResponseInit {
 	headers?: HeadersInit;
 	status?: number;
 	statusText?: string;
 }
 
-export type BodyInit =
+type BodyInit =
 	| Blob
 	| Buffer
 	| URLSearchParams
 	| NodeJS.ReadableStream
 	| string;
-export interface Body {
+type BodyType = { [K in keyof Body]: Body[K] };
+declare class Body {
+	constructor(body?: BodyInit, opts?: { size?: number });
+
 	readonly body: NodeJS.ReadableStream | null;
 	readonly bodyUsed: boolean;
 	readonly size: number;
@@ -109,14 +112,10 @@ export interface Body {
 	json(): Promise<unknown>;
 	text(): Promise<string>;
 }
-declare var Body: {
-	prototype: Body;
-	new(body?: BodyInit, opts?: {size?: number}): Body;
-}
 
-export type RequestRedirect = 'error' | 'follow' | 'manual';
-export type RequestInfo = string | Body;
-export class Request extends Body {
+type RequestRedirect = 'error' | 'follow' | 'manual';
+type RequestInfo = string | Body;
+declare class Request extends Body {
 	constructor(input: RequestInfo, init?: RequestInit);
 
 	/**
@@ -142,7 +141,7 @@ export class Request extends Body {
 	clone(): Request;
 }
 
-export class Response extends Body {
+declare class Response extends Body {
 	constructor(body?: BodyInit | null, init?: ResponseInit);
 
 	readonly headers: Headers;
@@ -154,9 +153,9 @@ export class Response extends Body {
 	clone(): Response;
 }
 
-export class FetchError extends Error {
+declare class FetchError extends Error {
 	constructor(message: string, type: string, systemError?: object);
-	
+
 	name: 'FetchError';
 	[Symbol.toStringTag]: 'FetchError';
 	type: string;
@@ -164,12 +163,39 @@ export class FetchError extends Error {
 	errno?: string;
 }
 
-export class AbortError extends Error {
+declare class AbortError extends Error {
 	type: string;
 	name: 'AbortError';
 	[Symbol.toStringTag]: 'AbortError';
 }
 
-export function isRedirect(code: number): boolean;
 
-export default function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
+declare function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
+declare class fetch {
+	static default: typeof fetch;
+}
+declare namespace fetch {
+	export function isRedirect(code: number): boolean;
+
+	export {
+		HeadersInit,
+		Headers,
+
+		RequestInit,
+		RequestRedirect,
+		RequestInfo,
+		Request,
+
+		BodyInit,
+
+		ResponseInit,
+		Response,
+
+		FetchError,
+		AbortError
+	};
+
+	export interface Body extends BodyType { }
+}
+
+export = fetch;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -12,7 +12,7 @@ type AbortSignal = {
 	removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;
 };
 
-type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>;
+type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>;
 
 /**
  * This Fetch API interface allows you to perform various actions on HTTP request and response headers.

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -3,10 +3,16 @@
 /* eslint-disable no-var, import/no-mutable-exports */
 
 import {Agent} from 'http';
-import {AbortSignal} from 'abort-controller';
-import Blob from 'fetch-blob';
+import * as Blob from 'fetch-blob';
 
-type HeadersInit = Headers | string[][] | Record<string, string>;
+export type AbortSignal = {
+	readonly aborted: boolean;
+
+    addEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { passive?: boolean; once?: boolean; }): void;
+    removeEventListener(type: "abort", listener: (this: AbortSignal, ev: Event) => any, options?: boolean | { capture?: boolean; }): void;
+};
+
+export type HeadersInit = Headers | string[][] | Record<string, string>;
 
 /**
  * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
@@ -15,40 +21,38 @@ type HeadersInit = Headers | string[][] | Record<string, string>;
  * You can add to this using methods like append() (see Examples.)
  * In all methods of this interface, header names are matched by case-insensitive byte sequence.
  * */
-interface Headers {
-	append: (name: string, value: string) => void;
-	delete: (name: string) => void;
-	get: (name: string) => string | null;
-	has: (name: string) => boolean;
-	set: (name: string, value: string) => void;
-	forEach: (
+export class Headers {
+	constructor(init?: HeadersInit);
+
+	append(name: string, value: string): void;
+	delete(name: string): void;
+	get(name: string): string | null;
+	has(name: string): boolean;
+	set(name: string, value: string): void;
+	forEach(
 		callbackfn: (value: string, key: string, parent: Headers) => void,
 		thisArg?: any
-	) => void;
+	): void;
 
-	[Symbol.iterator]: () => IterableIterator<[string, string]>;
+	[Symbol.iterator](): IterableIterator<[string, string]>;
 	/**
 	 * Returns an iterator allowing to go through all key/value pairs contained in this object.
 	 */
-	entries: () => IterableIterator<[string, string]>;
+	entries(): IterableIterator<[string, string]>;
 	/**
 	 * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
 	 */
-	keys: () => IterableIterator<string>;
+	keys(): IterableIterator<string>;
 	/**
 	 * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
 	 */
-	values: () => IterableIterator<string>;
+	values(): IterableIterator<string>;
 
 	/** Node-fetch extension */
-	raw: () => Record<string, string[]>;
+	raw(): Record<string, string[]>;
 }
-declare var Headers: {
-	prototype: Headers;
-	new (init?: HeadersInit): Headers;
-};
 
-interface RequestInit {
+export interface RequestInit {
 	/**
 	 * A BodyInit object or null to set request's body.
 	 */
@@ -82,35 +86,39 @@ interface RequestInit {
 	highWaterMark?: number;
 }
 
-interface ResponseInit {
+export interface ResponseInit {
 	headers?: HeadersInit;
 	status?: number;
 	statusText?: string;
 }
 
-type BodyInit =
+export type BodyInit =
 	| Blob
 	| Buffer
 	| URLSearchParams
 	| NodeJS.ReadableStream
 	| string;
-interface Body {
+export interface Body {
 	readonly body: NodeJS.ReadableStream | null;
 	readonly bodyUsed: boolean;
 	readonly size: number;
-	buffer: () => Promise<Buffer>;
-	arrayBuffer: () => Promise<ArrayBuffer>;
-	blob: () => Promise<Blob>;
-	json: () => Promise<unknown>;
-	text: () => Promise<string>;
+
+	buffer(): Promise<Buffer>;
+	arrayBuffer(): Promise<ArrayBuffer>;
+	blob(): Promise<Blob>;
+	json(): Promise<unknown>;
+	text(): Promise<string>;
 }
 declare var Body: {
 	prototype: Body;
-	new (body?: BodyInit, opts?: {size?: number}): Body;
-};
+	new(body?: BodyInit, opts?: {size?: number}): Body;
+}
 
-type RequestRedirect = 'error' | 'follow' | 'manual';
-interface Request extends Body {
+export type RequestRedirect = 'error' | 'follow' | 'manual';
+export type RequestInfo = string | Body;
+export class Request extends Body {
+	constructor(input: RequestInfo, init?: RequestInit);
+
 	/**
 	 * Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
 	 */
@@ -131,46 +139,30 @@ interface Request extends Body {
 	 * Returns the URL of request as a string.
 	 */
 	readonly url: string;
-	clone: () => Request;
+	clone(): Request;
 }
-type RequestInfo = string | Body;
-declare var Request: {
-	prototype: Request;
-	new (input: RequestInfo, init?: RequestInit): Request;
-};
 
-interface Response extends Body {
+export class Response extends Body {
+	constructor(body?: BodyInit | null, init?: ResponseInit);
+
 	readonly headers: Headers;
 	readonly ok: boolean;
 	readonly redirected: boolean;
 	readonly status: number;
 	readonly statusText: string;
 	readonly url: string;
-	clone: () => Response;
+	clone(): Response;
 }
 
-declare var Response: {
-	prototype: Response;
-	new (body?: BodyInit | null, init?: ResponseInit): Response;
-};
-
-declare function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
-
-declare namespace fetch {
-	function isRedirect(code: number): boolean;
-}
-
-interface FetchError extends Error {
+export class FetchError extends Error {
+	constructor(message: string, type: string, systemError?: object);
+	
 	name: 'FetchError';
 	[Symbol.toStringTag]: 'FetchError';
 	type: string;
 	code?: string;
 	errno?: string;
 }
-declare var FetchError: {
-	prototype: FetchError;
-	new (message: string, type: string, systemError?: object): FetchError;
-};
 
 export class AbortError extends Error {
 	type: string;
@@ -178,5 +170,6 @@ export class AbortError extends Error {
 	[Symbol.toStringTag]: 'AbortError';
 }
 
-export {Headers, Request, Response, FetchError};
-export default fetch;
+export function isRedirect(code: number): boolean;
+
+export default function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import fetch, {Request, Response, Headers, FetchError, AbortError} from '.';
+import AbortController from 'abort-controller';
 
 async function run() {
 	const getRes = await fetch('https://bigfile.com/test.zip');
@@ -58,6 +59,11 @@ async function run() {
 
 	const response = new Response();
 	expectType<string>(response.url);
+
+	const abortController = new AbortController()
+	const request = new Request("url", {
+		signal: abortController.signal
+	});
 }
 
 run().finally(() => {

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -89,6 +89,11 @@ async function run() {
 	// new Headers(['header', 'value']); // should not work
 	new Headers([['header', 'value']]);
 	new Headers(new Headers());
+	new Headers([
+		new Set(['a', '1']),
+		['b', '2'],
+		new Map([['a', null], ['3', null]]).keys()
+	]);
 
 	fetch.isRedirect = (code: number) => true;
 }

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -1,6 +1,9 @@
-import {expectType} from 'tsd';
-import fetch, {Request, Response, Headers, FetchError, AbortError} from '.';
+import {expectType, expectAssignable} from 'tsd';
 import AbortController from 'abort-controller';
+
+import fetch, {Request, Response, Headers, Body, FetchError, AbortError} from '.';
+import * as _fetch from '.';
+import __fetch = require('.');
 
 async function run() {
 	const getRes = await fetch('https://bigfile.com/test.zip');
@@ -57,16 +60,37 @@ async function run() {
 		}
 	}
 
+	// export *
+	const wildRes = await _fetch('https://google.com');
+	expectType<boolean>(wildRes.ok);
+	expectType<number>(wildRes.size);
+	expectType<number>(wildRes.status);
+	expectType<string>(wildRes.statusText);
+	expectType<() => Response>(wildRes.clone);
+
+	// export = require
+	const reqRes = await __fetch('https://google.com');
+	expectType<boolean>(reqRes.ok);
+	expectType<number>(reqRes.size);
+	expectType<number>(reqRes.status);
+	expectType<string>(reqRes.statusText);
+	expectType<() => Response>(reqRes.clone);
+
+	// Others
 	const response = new Response();
 	expectType<string>(response.url);
+	expectAssignable<Body>(response);
 
 	const abortController = new AbortController()
-	new Request('url', { signal: abortController.signal });
+	const request = new Request('url', { signal: abortController.signal });
+	expectAssignable<Body>(request);
 
 	new Headers({'Header': 'value'});
 	// new Headers(['header', 'value']); // should not work
 	new Headers([['header', 'value']]);
 	new Headers(new Headers());
+
+	fetch.isRedirect = (code: number) => true;
 }
 
 run().finally(() => {

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -61,9 +61,12 @@ async function run() {
 	expectType<string>(response.url);
 
 	const abortController = new AbortController()
-	const request = new Request("url", {
-		signal: abortController.signal
-	});
+	new Request('url', { signal: abortController.signal });
+
+	new Headers({'Header': 'value'});
+	// new Headers(['header', 'value']); // should not work
+	new Headers([['header', 'value']]);
+	new Headers(new Headers());
 }
 
 run().finally(() => {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
 			"lib": [
 				"es2018"
 			],
-			"allowSyntheticDefaultImports": true
+			"allowSyntheticDefaultImports": false,
+			"esModuleInterop": false
 		}
 	},
 	"xo": {

--- a/src/headers.js
+++ b/src/headers.js
@@ -24,7 +24,7 @@ function validateValue(value) {
 }
 
 /**
- * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string>[]} HeadersInit
+ * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>} HeadersInit
  */
 
 /**

--- a/src/headers.js
+++ b/src/headers.js
@@ -24,7 +24,7 @@ function validateValue(value) {
 }
 
 /**
- * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<string[]>} HeadersInit
+ * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
  */
 
 /**


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

- Export all types and interfaces
- Use `class` instead of `interface`+`var` where it's possible
- Use a minimal type for `AbortSignal` to avoid the need to import 'abort-controller' module
- Use method declaration instead of lambda declaration
- Avoid namespace creation that is not needed

**Which issue (if any) does this pull request address?**

- Impossible to construct `RequestInit` or `ResponseInit` object correctly:
```typescript
const init: RequestInit = { /* ... */ };
```

- Impossible to build a TypeScript project with no `abort-controller` dependency
- Not compatible with `v3.0.0-beta.5` types

**Is there anything you'd like reviewers to know?**

- check if `isRedirect()` is useable in this way.