### PR TITLE
chore: remove code duplication in custom errors

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -9,7 +9,7 @@ import Stream, {PassThrough} from 'stream';
 import {types} from 'util';
 
 import Blob from 'fetch-blob';
-import FetchError from './errors/fetch-error.js';
+import {FetchError} from './errors/fetch-error.js';
 import {isBlob, isURLSearchParameters, isAbortError} from './utils/is.js';
 
 const INTERNALS = Symbol('Body internals');

--- a/src/body.js
+++ b/src/body.js
@@ -10,7 +10,8 @@ import {types} from 'util';
 
 import Blob from 'fetch-blob';
 import {FetchError} from './errors/fetch-error.js';
-import {isBlob, isURLSearchParameters, isAbortError} from './utils/is.js';
+import {FetchBaseError} from './errors/base.js';
+import {isBlob, isURLSearchParameters} from './utils/is.js';
 
 const INTERNALS = Symbol('Body internals');
 
@@ -60,7 +61,7 @@ export default class Body {
 
 		if (body instanceof Stream) {
 			body.on('error', err => {
-				const error = isAbortError(err) ?
+				const error = err instanceof FetchBaseError ?
 					err :
 					new FetchError(`Invalid response body while trying to fetch ${this.url}: ${err.message}`, 'system', err);
 				this[INTERNALS].error = error;
@@ -198,7 +199,7 @@ async function consumeBody(data) {
 			accum.push(chunk);
 		}
 	} catch (error) {
-		if (isAbortError(error) || error instanceof FetchError) {
+		if (error instanceof FetchBaseError) {
 			throw error;
 		} else {
 			// Other errors, such as incorrect content-encoding

--- a/src/errors/abort-error.js
+++ b/src/errors/abort-error.js
@@ -1,27 +1,10 @@
+import {FetchBaseError} from './base.js';
+
 /**
- * Abort-error.js
- *
  * AbortError interface for cancelled requests
  */
-
-/**
- * Create AbortError instance
- *
- * @param   String      message      Error message for human
- * @param   String      type         Error type for machine
- * @param   String      systemError  For Node.js system error
- * @return  AbortError
- */
-export default class AbortError extends Error {
-	constructor(message) {
-		super(message);
-
-		this.type = 'aborted';
-		this.message = message;
-		this.name = 'AbortError';
-		this[Symbol.toStringTag] = 'AbortError';
-
-		// Hide custom error implementation details from end-users
-		Error.captureStackTrace(this, this.constructor);
+export class AbortError extends FetchBaseError {
+	constructor(message, type = 'aborted') {
+		super(message, type);
 	}
 }

--- a/src/errors/base.js
+++ b/src/errors/base.js
@@ -1,0 +1,20 @@
+'use strict';
+
+export class FetchBaseError extends Error {
+	constructor(message, type) {
+		super(message);
+		// Hide custom error implementation details from end-users
+		Error.captureStackTrace(this, this.constructor);
+
+		this.type = type;
+	}
+
+	get name() {
+		return this.constructor.name;
+	}
+
+	get [Symbol.toStringTag]() {
+		return this.constructor.name;
+	}
+}
+

--- a/src/errors/fetch-error.js
+++ b/src/errors/fetch-error.js
@@ -1,34 +1,26 @@
+
+import {FetchBaseError} from './base.js';
+
 /**
- * Fetch-error.js
- *
+ * @typedef {{ address?: string, code: string, dest?: string, errno: number, info?: object, message: string, path?: string, port?: number, syscall: string}} SystemError
+*/
+
+/**
  * FetchError interface for operational errors
  */
-
-/**
- * Create FetchError instance
- *
- * @param   String      message      Error message for human
- * @param   String      type         Error type for machine
- * @param   Object      systemError  For Node.js system error
- * @return  FetchError
- */
-export default class FetchError extends Error {
+export class FetchError extends FetchBaseError {
+	/**
+	 * @param  {string} message -      Error message for human
+	 * @param  {string} type -        Error type for machine
+	 * @param  {SystemError} [systemError] - For Node.js system error
+	 */
 	constructor(message, type, systemError) {
-		super(message);
-
-		this.message = message;
-		this.type = type;
-		this.name = 'FetchError';
-		this[Symbol.toStringTag] = 'FetchError';
-
+		super(message, type);
 		// When err.type is `system`, err.erroredSysCall contains system error and err.code contains system error code
 		if (systemError) {
 			// eslint-disable-next-line no-multi-assign
 			this.code = this.errno = systemError.code;
-			this.erroredSysCall = systemError;
+			this.erroredSysCall = systemError.syscall;
 		}
-
-		// Hide custom error implementation details from end-users
-		Error.captureStackTrace(this, this.constructor);
 	}
 }

--- a/src/errors/fetch-error.js
+++ b/src/errors/fetch-error.js
@@ -11,7 +11,7 @@ import {FetchBaseError} from './base.js';
 export class FetchError extends FetchBaseError {
 	/**
 	 * @param  {string} message -      Error message for human
-	 * @param  {string} type -        Error type for machine
+	 * @param  {string} [type] -        Error type for machine
 	 * @param  {SystemError} [systemError] - For Node.js system error
 	 */
 	constructor(message, type, systemError) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,8 @@ import {writeToStream, getTotalBytes} from './body.js';
 import Response from './response.js';
 import Headers, {fromRawHeaders} from './headers.js';
 import Request, {getNodeRequestOptions} from './request.js';
-import FetchError from './errors/fetch-error.js';
-import AbortError from './errors/abort-error.js';
+import {FetchError} from './errors/fetch-error.js';
+import {AbortError} from './errors/abort-error.js';
 import {isRedirect} from './utils/is-redirect.js';
 
 export {Headers, Request, Response, FetchError, AbortError, isRedirect};

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -57,12 +57,3 @@ export const isAbortSignal = object => {
 	);
 };
 
-/**
- * Check if `obj` is an instance of AbortError.
- *
- * @param  {*} obj
- * @return {boolean}
- */
-export const isAbortError = object => {
-	return object[NAME] === 'AbortError';
-};

--- a/test/main.js
+++ b/test/main.js
@@ -28,7 +28,7 @@ import fetch, {
 	Request,
 	Response
 } from '../src/index.js';
-import FetchErrorOrig from '../src/errors/fetch-error.js';
+import {FetchError as FetchErrorOrig} from '../src/errors/fetch-error.js';
 import HeadersOrig, {fromRawHeaders} from '../src/headers.js';
 import RequestOrig from '../src/request.js';
 import ResponseOrig from '../src/response.js';


### PR DESCRIPTION
In the current implementation `AbortError` and `FetchError` pretty much repeating the same code (plus some magic strings). This PR moves common functionality into a base class and removes code duplication.

It also removes `isAbortError` and uses `instanceof FetchBaseError` as those errors are our internal classes and always instantiating from it.