### PR TITLE
Drop custom Promises and refactor to `async` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ See Jason Miller's [isomorphic-unfetch](https://www.npmjs.com/package/isomorphic
 
 - Stay consistent with `window.fetch` API.
 - Make conscious trade-off when following [WHATWG fetch spec][whatwg-fetch] and [stream spec](https://streams.spec.whatwg.org/) implementation details, document known differences.
-- Use native promise, but allow substituting it with [insert your favorite promise library].
+- Use native promise and async functions.
 - Use native Node streams for body, on both request and response.
-- Decode content encoding (gzip/deflate) properly, and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
+- Decode content encoding (gzip/deflate/brotli) properly, and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
 - Useful extensions such as redirect limit, response size limit, [explicit errors][error-handling.md] for troubleshooting.
 
 ## Difference from client-side fetch

--- a/README.md
+++ b/README.md
@@ -116,15 +116,6 @@ const fetch = require('node-fetch');
 import fetch from 'node-fetch';
 ```
 
-If you are using a Promise library other than native, set it through `fetch.Promise`:
-
-```js
-const fetch = require('node-fetch');
-const Bluebird = require('bluebird');
-
-fetch.Promise = Bluebird;
-```
-
 If you want to patch the global object in node:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 		"mocha": "^7.1.2",
 		"p-timeout": "^3.2.0",
 		"parted": "^0.1.1",
-		"promise": "^8.1.0",
 		"resumer": "0.0.0",
 		"rollup": "^2.10.8",
 		"string-to-arraybuffer": "^1.0.2",

--- a/src/body.js
+++ b/src/body.js
@@ -217,11 +217,14 @@ async function consumeBody(data) {
 	}
 
 	if (!abort) {
-		try {
-			return Buffer.concat(accum, accumBytes);
-		} catch (error) {
-			// Handle streams that have accumulated too much data (issue #414)
-			throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);
+		if (body.readableEnded === true || body._readableState.ended === true) {
+			try {
+				return Buffer.concat(accum, accumBytes);
+			} catch (error) {
+				throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);
+			}
+		} else {
+			throw new FetchError(`Premature close of server response while trying to fetch ${data.url}`);
 		}
 	}
 }

--- a/src/body.js
+++ b/src/body.js
@@ -5,7 +5,7 @@
  * Body interface provides common methods for Request and Response
  */
 
-import Stream, {finished, PassThrough} from 'stream';
+import Stream, {PassThrough} from 'stream';
 import {types} from 'util';
 
 import Blob from 'fetch-blob';
@@ -148,22 +148,22 @@ Object.defineProperties(Body.prototype, {
  *
  * @return  Promise
  */
-const consumeBody = data => {
+async function consumeBody(data) {
 	if (data[INTERNALS].disturbed) {
-		return Body.Promise.reject(new TypeError(`body used already for: ${data.url}`));
+		throw new TypeError(`body used already for: ${data.url}`);
 	}
 
 	data[INTERNALS].disturbed = true;
 
 	if (data[INTERNALS].error) {
-		return Body.Promise.reject(data[INTERNALS].error);
+		throw data[INTERNALS].error;
 	}
 
 	let {body} = data;
 
 	// Body is null
 	if (body === null) {
-		return Body.Promise.resolve(Buffer.alloc(0));
+		return Buffer.alloc(0);
 	}
 
 	// Body is blob
@@ -173,12 +173,12 @@ const consumeBody = data => {
 
 	// Body is buffer
 	if (Buffer.isBuffer(body)) {
-		return Body.Promise.resolve(body);
+		return body;
 	}
 
 	/* c8 ignore next 3 */
 	if (!(body instanceof Stream)) {
-		return Body.Promise.resolve(Buffer.alloc(0));
+		return Buffer.alloc(0);
 	}
 
 	// Body is stream
@@ -187,47 +187,44 @@ const consumeBody = data => {
 	let accumBytes = 0;
 	let abort = false;
 
-	return new Body.Promise((resolve, reject) => {
-		body.on('data', chunk => {
+	try {
+		for await (const chunk of body) {
 			if (abort || chunk === null) {
 				return;
 			}
 
 			if (data.size && accumBytes + chunk.length > data.size) {
 				abort = true;
-				reject(new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size'));
-				return;
+				throw new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size');
 			}
 
 			accumBytes += chunk.length;
 			accum.push(chunk);
-		});
-
-		finished(body, {writable: false}, err => {
-			if (err) {
-				if (isAbortError(err)) {
-					// If the request was aborted, reject with this Error
-					abort = true;
-					reject(err);
-				} else {
-					// Other errors, such as incorrect content-encoding
-					reject(new FetchError(`Invalid response body while trying to fetch ${data.url}: ${err.message}`, 'system', err));
-				}
-			} else {
-				if (abort) {
-					return;
-				}
-
-				try {
-					resolve(Buffer.concat(accum, accumBytes));
-				} catch (error) {
-					// Handle streams that have accumulated too much data (issue #414)
-					reject(new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error));
-				}
+		}
+	} catch (error) {
+		if (isAbortError(error)) {
+			// If the request was aborted, reject with this Error
+			abort = true;
+			throw error;
+		} else {
+			// Other errors, such as incorrect content-encoding
+			if (error instanceof FetchError) {
+				throw error;
 			}
-		});
-	});
-};
+
+			throw new FetchError(`Invalid response body while trying to fetch ${data.url}: ${error.message}`, 'system', error);
+		}
+	}
+
+	if (!abort) {
+		try {
+			return Buffer.concat(accum, accumBytes);
+		} catch (error) {
+			// Handle streams that have accumulated too much data (issue #414)
+			throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);
+		}
+	}
+}
 
 /**
  * Clone body given Res/Req instance
@@ -370,5 +367,3 @@ export const writeToStream = (dest, {body}) => {
 	}
 };
 
-// Expose Promise
-Body.Promise = global.Promise;

--- a/src/body.js
+++ b/src/body.js
@@ -188,9 +188,10 @@ async function consumeBody(data) {
 
 	try {
 		for await (const chunk of body) {
-			const chunkSize = Buffer.isBuffer(chunk) ? chunk.byteLength : Buffer.from(chunk).byteLength;
-			if (data.size > 0 && accumBytes + chunkSize > data.size) {
-				throw new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size');
+			if (data.size > 0 && accumBytes + chunk.length > data.size) {
+				const err = new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size')
+				body.destroy(err)
+				throw err;
 			}
 
 			accumBytes += chunk.length;

--- a/src/body.js
+++ b/src/body.js
@@ -189,8 +189,8 @@ async function consumeBody(data) {
 	try {
 		for await (const chunk of body) {
 			if (data.size > 0 && accumBytes + chunk.length > data.size) {
-				const err = new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size')
-				body.destroy(err)
+				const err = new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size');
+				body.destroy(err);
 				throw err;
 			}
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,12 +29,7 @@ export {Headers, Request, Response, FetchError, AbortError, isRedirect};
  * @param   Object   opts  Fetch options
  * @return  Promise
  */
-export default function fetch(url, options_) {
-	// Allow custom promise
-	if (!fetch.Promise) {
-		throw new Error('native promise missing, set fetch.Promise to your favorite alternative');
-	}
-
+export default async function fetch(url, options_) {
 	// Regex for data uri
 	const dataUriRegex = /^\s*data:([a-z]+\/[a-z]+(;[a-z-]+=[a-z-]+)?)?(;base64)?,[\w!$&',()*+;=\-.~:@/?%\s]*\s*$/i;
 
@@ -42,17 +37,17 @@ export default function fetch(url, options_) {
 	if (dataUriRegex.test(url)) {
 		const data = dataURIToBuffer(url);
 		const response = new Response(data, {headers: {'Content-Type': data.type}});
-		return fetch.Promise.resolve(response);
+		return response;
 	}
 
 	// If invalid data uri
 	if (url.toString().startsWith('data:')) {
 		const request = new Request(url, options_);
-		return fetch.Promise.reject(new FetchError(`[${request.method}] ${request.url} invalid URL`, 'system'));
+		throw new FetchError(`[${request.method}] ${request.url} invalid URL`, 'system');
 	}
 
 	// Wrap http.request into fetch
-	return new fetch.Promise((resolve, reject) => {
+	return new Promise((resolve, reject) => {
 		// Build request object
 		const request = new Request(url, options_);
 		const options = getNodeRequestOptions(request);
@@ -288,5 +283,3 @@ export default function fetch(url, options_) {
 	});
 }
 
-// Expose Promise
-fetch.Promise = global.Promise;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import zlib from 'zlib';
 import Stream, {PassThrough, pipeline as pump} from 'stream';
 import dataURIToBuffer from 'data-uri-to-buffer';
 
-import Body, {writeToStream, getTotalBytes} from './body.js';
+import {writeToStream, getTotalBytes} from './body.js';
 import Response from './response.js';
 import Headers, {fromRawHeaders} from './headers.js';
 import Request, {getNodeRequestOptions} from './request.js';
@@ -50,8 +50,6 @@ export default function fetch(url, options_) {
 		const request = new Request(url, options_);
 		return fetch.Promise.reject(new FetchError(`[${request.method}] ${request.url} invalid URL`, 'system'));
 	}
-
-	Body.Promise = fetch.Promise;
 
 	// Wrap http.request into fetch
 	return new fetch.Promise((resolve, reject) => {

--- a/test/main.js
+++ b/test/main.js
@@ -601,8 +601,9 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			expect(res.ok).to.be.true;
-			return expect(res.text()).to.eventually.be.rejectedWith(Error)
-				.and.have.property('message').includes('Premature close');
+			return res.text().then(text => {
+				expect(text).to.equal('foo');
+			});
 		});
 	});
 

--- a/test/main.js
+++ b/test/main.js
@@ -10,7 +10,6 @@ import chai from 'chai';
 import chaiPromised from 'chai-as-promised';
 import chaiIterator from 'chai-iterator';
 import chaiString from 'chai-string';
-import then from 'promise';
 import resumer from 'resumer';
 import FormData from 'form-data';
 import stringToArrayBuffer from 'string-to-arraybuffer';
@@ -77,27 +76,8 @@ describe('node-fetch', () => {
 	it('should return a promise', () => {
 		const url = `${base}hello`;
 		const p = fetch(url);
-		expect(p).to.be.an.instanceof(fetch.Promise);
+		expect(p).to.be.an.instanceof(Promise);
 		expect(p).to.have.property('then');
-	});
-
-	it('should allow custom promise', () => {
-		const url = `${base}hello`;
-		const old = fetch.Promise;
-		fetch.Promise = then;
-		expect(fetch(url)).to.be.an.instanceof(then);
-		expect(fetch(url)).to.not.be.an.instanceof(old);
-		fetch.Promise = old;
-	});
-
-	it('should throw error when no promise implementation are found', () => {
-		const url = `${base}hello`;
-		const old = fetch.Promise;
-		fetch.Promise = undefined;
-		expect(() => {
-			fetch(url);
-		}).to.throw(Error);
-		fetch.Promise = old;
 	});
 
 	it('should expose Headers, Response and Request constructors', () => {
@@ -601,9 +581,8 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			expect(res.ok).to.be.true;
-			return res.text().then(text => {
-				expect(text).to.equal('foo');
-			});
+			return expect(res.text()).to.eventually.be.rejectedWith(Error)
+				.and.have.property('message').includes('Premature close');
 		});
 	});
 

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -305,9 +305,9 @@ export default class TestServer {
 		if (p === '/error/premature') {
 			res.writeHead(200, {'content-length': 50});
 			res.write('foo');
-			setTimeout(() => {
-				res.destroy();
-			}, 100);
+			setImmediate(() => {
+				res.socket.destroy();
+			});
 		}
 
 		if (p === '/error/json') {

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -305,9 +305,9 @@ export default class TestServer {
 		if (p === '/error/premature') {
 			res.writeHead(200, {'content-length': 50});
 			res.write('foo');
-			setImmediate(() => {
-				res.socket.destroy();
-			});
+			setTimeout(() => {
+				res.destroy();
+			}, 100);
 		}
 
 		if (p === '/error/json') {


### PR DESCRIPTION
Fixes #844 and drops custom Promises.

This PR didn't complete the refactoring of `index.js` into `async` function (as it way more complicated and time-consuming task), but it can be done by iterations later on as non-breaking changes, now when we drop support for custom promises.

No changes to tests, except for the removal of testing for custom promises.
