### PR TITLE
More permissive `isStream` logic

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -15,8 +15,9 @@ import {isBlob, isURLSearchParameters, isAbortError} from './utils/is.js';
 const INTERNALS = Symbol('Body internals');
 
 function isStream(body) {
-	return body instanceof Stream || (body && body.constructor && /Stream/.exec(body.constructor.name))
+	return body instanceof Stream || (body && body.constructor && /Stream/.exec(body.constructor.name));
 }
+
 /**
  * Body mixin
  *

--- a/src/body.js
+++ b/src/body.js
@@ -15,7 +15,7 @@ import {isBlob, isURLSearchParameters, isAbortError} from './utils/is.js';
 const INTERNALS = Symbol('Body internals');
 
 function isStream(body) {
-	return body instanceof Stream || (body.constructor && /Stream/.exec(body.constructor.name))
+	return body instanceof Stream || (body && body.constructor && /Stream/.exec(body.constructor.name))
 }
 /**
  * Body mixin


### PR DESCRIPTION
To support other stream APIs e.g. `web-streams-ponyfill`

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: tweak to logic

**What changes did you make? (provide an overview)**

For other stream APIs e.g. `web-streams-ponyfill`, they're not detected as streams so they get serialised to `[object Object]`. This change relaxes the `isStream` constraint so they get treated as `stream` objects, and since they imlpement the same methods they just work.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**

More than happy to discuss alternative checks here, but `instanceof` seems like too strict a check, when there's multiple Stream packages that are compatible.