### PR TITLE
Add `httpOptions` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,8 @@ The default values are shown after each option key.
     compress: true,         // support gzip/deflate content encoding. false to disable
     size: 0,                // maximum response body size in bytes. 0 to disable
     agent: null,            // http(s).Agent instance or function that returns an instance (see below)
-    highWaterMark: 16384    // the maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource.
+	highWaterMark: 16384,    // the maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource.
+	extraHTTPOptions: {}	// additional options to include in http(s).request options that cannot be configured by the http(s).Agent override.
 }
 ```
 
@@ -536,6 +537,13 @@ const fetch = require('node-fetch');
 	return res.clone().buffer();
 })();
 ```
+
+
+#### Extra HTTP Options
+
+Extra options to pass to http.request.
+See [`http.request`](https://nodejs.org/api/http.html#http_http_request_url_options_callback) for more information.
+
 
 <a id="class-request"></a>
 

--- a/README.md
+++ b/README.md
@@ -539,9 +539,9 @@ const fetch = require('node-fetch');
 ```
 
 
-#### Extra HTTP Options
+#### HTTP Options
 
-Extra options to pass to http.request.
+Additional options to pass to http.request.
 See [`http.request`](https://nodejs.org/api/http.html#http_http_request_url_options_callback) for more information.
 
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ The default values are shown after each option key.
     size: 0,                // maximum response body size in bytes. 0 to disable
     agent: null,            // http(s).Agent instance or function that returns an instance (see below)
 	highWaterMark: 16384,    // the maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource.
-	extraHTTPOptions: {}	// additional options to include in http(s).request options that cannot be configured by the http(s).Agent override.
+	httpOptions: {}	// additional options to include in http(s).request options that cannot be configured by the http(s).Agent override.
 }
 ```
 

--- a/src/request.js
+++ b/src/request.js
@@ -100,7 +100,7 @@ export default class Request extends Body {
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
 		this.highWaterMark = init.highWaterMark || input.highWaterMark || 16384;
-		this.extraHTTPOptions = init.extraHTTPOptions || input.extraHTTPOptions || {};
+		this.httpOptions = init.httpOptions || input.httpOptions || {};
 	}
 
 	get method() {
@@ -204,7 +204,7 @@ export const getNodeRequestOptions = request => {
 
 	// Manually spread the URL object instead of spread syntax
 	const requestOptions = {
-		...request.extraHTTPOptions,
+		...request.httpOptions,
 		path: parsedURL.pathname + search,
 		pathname: parsedURL.pathname,
 		hostname: parsedURL.hostname,

--- a/src/request.js
+++ b/src/request.js
@@ -100,6 +100,7 @@ export default class Request extends Body {
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
 		this.highWaterMark = init.highWaterMark || input.highWaterMark || 16384;
+		this.extraHTTPOptions = init.extraHTTPOptions || input.extraHTTPOptions || {};
 	}
 
 	get method() {
@@ -203,6 +204,7 @@ export const getNodeRequestOptions = request => {
 
 	// Manually spread the URL object instead of spread syntax
 	const requestOptions = {
+		...request.extraHTTPOptions,
 		path: parsedURL.pathname + search,
 		pathname: parsedURL.pathname,
 		hostname: parsedURL.hostname,


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Added extraHTTPOptions option that gets passed through to the http(s).request options here https://nodejs.org/docs/latest-v12.x/api/http.html#http_http_request_options_callback.

It looks like there was recently a similar discussion around this for TLS Options, which can be configured on the agent (undocumented). The impetus for this PR is the ability to pass the `insecureHTTPParser` option, which as far as I can tell can't be set on the agent.

**Which issue (if any) does this pull request address?**
https://github.com/node-fetch/node-fetch/issues/724

**Is there anything you'd like reviewers to know?**

Here's some background reading: https://github.com/nodejs/node/issues/27711
Sounds like it's a fairly common issue with the Incapsula CDN.

**Why not just use the Agent?**
```js
const https = require('https');
const fetch = require('node-fetch');
async function main() {
    const agent = new https.Agent({
        insecureHTTPParser: true // not a valid option in https://nodejs.org/api/http.html#http_new_agent_options
    });
    const uri = 'https://cams.jacksonhole.com/webcam/SouthHoback.jpg?1590589817';
    const data = await fetch(uri, {
        agent
    });
    console.log(data)
}

main().catch(console.error);
```

Running this on node 12.x LTS will get you this:
```
➜  node test.js
FetchError: request to https://www.dezeen.com/robots.txt failed, reason: Parse Error: Invalid header value char
    at ClientRequest.<anonymous> (/path/to/project/node_modules/node-fetch/lib/index.js:1455:11)
    at ClientRequest.emit (events.js:315:20)
    at TLSSocket.socketOnData (_http_client.js:476:9)
    at TLSSocket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at TLSSocket.Readable.push (_stream_readable.js:212:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23) {
  type: 'system',
  errno: 'HPE_INVALID_HEADER_TOKEN',
  code: 'HPE_INVALID_HEADER_TOKEN'
}
```

We need the `insecureHTTPParser` option on the request to override this on a per-call basis. https://nodejs.org/api/http.html#http_http_request_options_callback