### PR TITLE
fix: lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,126 +1,126 @@
 {
-	"name": "node-fetch",
-	"version": "3.0.0-beta.6-exportfix",
-	"description": "A light-weight module that brings window.fetch to node.js",
-	"main": "./dist/index.cjs",
-	"module": "./src/index.js",
-	"sideEffects": false,
-	"type": "module",
-	"exports": {
-		"import": "./src/index.js",
-		"require": "./dist/index.cjs"
-	},
-	"files": [
-		"src",
-		"dist",
-		"@types/index.d.ts"
-	],
-	"types": "./@types/index.d.ts",
-	"engines": {
-		"node": ">=10.16"
-	},
-	"scripts": {
-		"build": "rollup -c",
-		"test": "node --experimental-modules node_modules/c8/bin/c8 --reporter=html --reporter=lcov --reporter=text --check-coverage node --experimental-modules node_modules/mocha/bin/mocha",
-		"coverage": "c8 report --reporter=text-lcov | coveralls",
-		"test-types": "tsd",
-		"lint": "xo",
-		"prepublishOnly": "node ./test/commonjs/test-artifact.js"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/node-fetch/node-fetch.git"
-	},
-	"keywords": [
-		"fetch",
-		"http",
-		"promise"
-	],
-	"author": "David Frank",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/node-fetch/node-fetch/issues"
-	},
-	"homepage": "https://github.com/node-fetch/node-fetch",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/node-fetch"
-	},
-	"devDependencies": {
-		"abort-controller": "^3.0.0",
-		"abortcontroller-polyfill": "^1.4.0",
-		"c8": "^7.1.2",
-		"chai": "^4.2.0",
-		"chai-as-promised": "^7.1.1",
-		"chai-iterator": "^3.0.2",
-		"chai-string": "^1.5.0",
-		"coveralls": "^3.1.0",
-		"delay": "^4.3.0",
-		"form-data": "^3.0.0",
-		"mocha": "^7.1.2",
-		"p-timeout": "^3.2.0",
-		"parted": "^0.1.1",
-		"resumer": "0.0.0",
-		"rollup": "^2.10.8",
-		"string-to-arraybuffer": "^1.0.2",
-		"tsd": "^0.11.0",
-		"xo": "^0.30.0"
-	},
-	"dependencies": {
-		"data-uri-to-buffer": "^3.0.1",
-		"fetch-blob": "^1.0.6"
-	},
-	"tsd": {
-		"cwd": "@types",
-		"compilerOptions": {
-			"target": "esnext",
-			"lib": [
-				"es2018"
-			],
-			"allowSyntheticDefaultImports": false,
-			"esModuleInterop": false
-		}
-	},
-	"xo": {
-		"envs": [
-			"node",
-			"browser"
-		],
-		"rules": {
-			"complexity": 0,
-			"import/extensions": 0,
-			"import/no-useless-path-segments": 0,
-			"unicorn/import-index": 0,
-			"capitalized-comments": 0
-		},
-		"ignores": [
-			"dist",
-			"@types"
-		],
-		"overrides": [
-			{
-				"files": "test/**/*.js",
-				"envs": [
-					"node",
-					"mocha"
-				],
-				"rules": {
-					"max-nested-callbacks": 0,
-					"no-unused-expressions": 0,
-					"new-cap": 0,
-					"guard-for-in": 0,
-					"unicorn/prevent-abbreviations": 0,
-					"promise/prefer-await-to-then": 0,
-					"ava/no-import-test-files": 0
-				}
-			},
-			{
-				"files": "example.js",
-				"rules": {
-					"import/no-extraneous-dependencies": 0
-				}
-			}
-		]
-	},
-	"runkitExampleFilename": "example.js"
+    "name": "node-fetch",
+    "version": "3.0.0-beta.6-exportfix",
+    "description": "A light-weight module that brings window.fetch to node.js",
+    "main": "./dist/index.cjs",
+    "module": "./src/index.js",
+    "sideEffects": false,
+    "type": "module",
+    "exports": {
+        "import": "./src/index.js",
+        "require": "./dist/index.cjs"
+    },
+    "files": [
+        "src",
+        "dist",
+        "@types/index.d.ts"
+    ],
+    "types": "./@types/index.d.ts",
+    "engines": {
+        "node": ">=10.16"
+    },
+    "scripts": {
+        "build": "rollup -c",
+        "test": "node --experimental-modules node_modules/c8/bin/c8 --reporter=html --reporter=lcov --reporter=text --check-coverage node --experimental-modules node_modules/mocha/bin/mocha",
+        "coverage": "c8 report --reporter=text-lcov | coveralls",
+        "test-types": "tsd",
+        "lint": "xo",
+        "prepublishOnly": "node ./test/commonjs/test-artifact.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/node-fetch/node-fetch.git"
+    },
+    "keywords": [
+        "fetch",
+        "http",
+        "promise"
+    ],
+    "author": "David Frank",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/node-fetch/node-fetch/issues"
+    },
+    "homepage": "https://github.com/node-fetch/node-fetch",
+    "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+    },
+    "devDependencies": {
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "c8": "^7.1.2",
+        "chai": "^4.2.0",
+        "chai-as-promised": "^7.1.1",
+        "chai-iterator": "^3.0.2",
+        "chai-string": "^1.5.0",
+        "coveralls": "^3.1.0",
+        "delay": "^4.3.0",
+        "form-data": "^3.0.0",
+        "mocha": "^7.2.0",
+        "p-timeout": "^3.2.0",
+        "parted": "^0.1.1",
+        "resumer": "0.0.0",
+        "rollup": "^2.13.1",
+        "string-to-arraybuffer": "^1.0.2",
+        "tsd": "^0.11.0",
+        "xo": "^0.32.0"
+    },
+    "dependencies": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^1.0.6"
+    },
+    "tsd": {
+        "cwd": "@types",
+        "compilerOptions": {
+            "target": "esnext",
+            "lib": [
+                "es2018"
+            ],
+            "allowSyntheticDefaultImports": false,
+            "esModuleInterop": false
+        }
+    },
+    "xo": {
+        "envs": [
+            "node",
+            "browser"
+        ],
+        "rules": {
+            "complexity": 0,
+            "import/extensions": 0,
+            "import/no-useless-path-segments": 0,
+            "unicorn/import-index": 0,
+            "capitalized-comments": 0
+        },
+        "ignores": [
+            "dist",
+            "@types"
+        ],
+        "overrides": [
+            {
+                "files": "test/**/*.js",
+                "envs": [
+                    "node",
+                    "mocha"
+                ],
+                "rules": {
+                    "max-nested-callbacks": 0,
+                    "no-unused-expressions": 0,
+                    "new-cap": 0,
+                    "guard-for-in": 0,
+                    "unicorn/prevent-abbreviations": 0,
+                    "promise/prefer-await-to-then": 0,
+                    "ava/no-import-test-files": 0
+                }
+            },
+            {
+                "files": "example.js",
+                "rules": {
+                    "import/no-extraneous-dependencies": 0
+                }
+            }
+        ]
+    },
+    "runkitExampleFilename": "example.js"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import {builtinModules} from 'module';
 import {dependencies} from './package.json';
 
-export default {
+const configuration = {
 	input: 'src/index.js',
 	output: {
 		file: 'dist/index.cjs',
@@ -16,3 +16,5 @@ export default {
 	},
 	external: [...builtinModules, ...Object.keys(dependencies)]
 };
+
+export default configuration;

--- a/test/utils/chai-timeout.js
+++ b/test/utils/chai-timeout.js
@@ -1,6 +1,6 @@
 import pTimeout from 'p-timeout';
 
-export default ({Assertion}, utils) => {
+const chaiTimeout = ({Assertion}, utils) => {
 	utils.addProperty(Assertion.prototype, 'timeout', async function () {
 		let timeouted = false;
 		await pTimeout(this._obj, 150, () => {
@@ -13,3 +13,5 @@ export default ({Assertion}, utils) => {
 		);
 	});
 };
+
+export default chaiTimeout;


### PR DESCRIPTION
The latest version of `xo` introduced some new rules, one of which is the `unicorn/no-reduce`. More information available here: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/623.

My question is - do we want to use this rule or ignore it. It seems a bit controversial.