### PR TITLE
[Spec] Should check body _source_ on redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	],
 	"types": "./@types/index.d.ts",
 	"engines": {
-		"node": ">=10.16"
+		"node": ">=10.17"
 	},
 	"scripts": {
 		"build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 		"mocha": "^7.1.2",
 		"p-timeout": "^3.2.0",
 		"parted": "^0.1.1",
-		"resumer": "0.0.0",
 		"rollup": "^2.10.8",
 		"string-to-arraybuffer": "^1.0.2",
 		"tsd": "^0.11.0",

--- a/src/body.js
+++ b/src/body.js
@@ -208,7 +208,10 @@ async function consumeBody(data) {
 
 	if (body.readableEnded === true || body._readableState.ended === true) {
 		try {
-			if(accum.every(c => typeof c === 'string')) return Buffer.from(accum.join(''));
+			if (accum.every(c => typeof c === 'string')) {
+				return Buffer.from(accum.join(''));
+			}
+
 			return Buffer.concat(accum, accumBytes);
 		} catch (error) {
 			throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);

--- a/src/body.js
+++ b/src/body.js
@@ -208,6 +208,7 @@ async function consumeBody(data) {
 
 	if (body.readableEnded === true || body._readableState.ended === true) {
 		try {
+			if(accum.every(c => typeof c === 'string')) return Buffer.from(accum.join(''));
 			return Buffer.concat(accum, accumBytes);
 		} catch (error) {
 			throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import zlib from 'zlib';
 import Stream, {PassThrough, pipeline as pump} from 'stream';
 import dataUriToBuffer from 'data-uri-to-buffer';
 
-import {writeToStream, getTotalBytes} from './body.js';
+import {writeToStream} from './body.js';
 import Response from './response.js';
 import Headers, {fromRawHeaders} from './headers.js';
 import Request, {getNodeRequestOptions} from './request.js';

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ export default async function fetch(url, options_) {
 						};
 
 						// HTTP-redirect fetch step 9
-						if (response_.statusCode !== 303 && request.body && getTotalBytes(request) === null) {
+						if (response_.statusCode !== 303 && request.body && options_.body instanceof Stream.Readable) {
 							reject(new FetchError('Cannot follow redirect with body being a readable stream', 'unsupported-redirect'));
 							finalize();
 							return;

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,5 @@
 // Test tools
+/* eslint-disable node/no-unsupported-features/node-builtins */
 import zlib from 'zlib';
 import crypto from 'crypto';
 import http from 'http';
@@ -1967,18 +1968,16 @@ describe('node-fetch', () => {
 
 	// Issue #414
 	it('should reject if attempt to accumulate body stream throws', () => {
-		const res = new Response(stream.Readable.from((async function* () {
+		const res = new Response(stream.Readable.from((async function * () {
 			yield Buffer.from('tada');
 			await new Promise(resolve => setTimeout(resolve, 200));
-			yield { tada: 'yes' }
+			yield {tada: 'yes'};
 		})()));
 
-		const textPromise = res.text();
-
-		return expect(textPromise).to.eventually.be.rejected
+		return expect(res.text()).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
 			.and.include({type: 'system'})
-			.and.have.property('message').that.includes('Could not create Buffer')
+			.and.have.property('message').that.include('Could not create Buffer');
 	});
 
 	it('supports supplying a lookup function to the agent', () => {
@@ -2040,7 +2039,7 @@ describe('node-fetch', () => {
 		const url = `${base}hello`;
 		const bodyContent = 'a=1';
 
-		let streamBody = stream.Readable.from(bodyContent);
+		const streamBody = stream.Readable.from(bodyContent);
 		const streamRequest = new Request(url, {
 			method: 'POST',
 			body: streamBody,

--- a/test/request.js
+++ b/test/request.js
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unsupported-features/node-builtins */
+
 import stream from 'stream';
 import http from 'http';
 import polyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
@@ -200,7 +202,7 @@ describe('Request', () => {
 
 	it('should support clone() method', () => {
 		const url = base;
-		let body = stream.Readable.from('a=1');
+		const body = stream.Readable.from('a=1');
 		const agent = new http.Agent();
 		const {signal} = new AbortController();
 		const request = new Request(url, {

--- a/test/request.js
+++ b/test/request.js
@@ -4,7 +4,6 @@ import polyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
 import chai from 'chai';
 import FormData from 'form-data';
 import Blob from 'fetch-blob';
-import resumer from 'resumer';
 import stringToArrayBuffer from 'string-to-arraybuffer';
 
 import TestServer from './utils/server.js';
@@ -201,8 +200,7 @@ describe('Request', () => {
 
 	it('should support clone() method', () => {
 		const url = base;
-		let body = resumer().queue('a=1').end();
-		body = body.pipe(new stream.PassThrough());
+		let body = stream.Readable.from('a=1');
 		const agent = new http.Agent();
 		const {signal} = new AbortController();
 		const request = new Request(url, {

--- a/test/response.js
+++ b/test/response.js
@@ -1,6 +1,5 @@
 import * as stream from 'stream';
 import chai from 'chai';
-import resumer from 'resumer';
 import stringToArrayBuffer from 'string-to-arraybuffer';
 import Blob from 'fetch-blob';
 import {Response} from '../src/index.js';
@@ -54,9 +53,7 @@ describe('Response', () => {
 	});
 
 	it('should support empty options', () => {
-		let body = resumer().queue('a=1').end();
-		body = body.pipe(new stream.PassThrough());
-		const res = new Response(body);
+		const res = new Response(stream.Readable.from('a=1'));
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});
@@ -107,8 +104,7 @@ describe('Response', () => {
 	});
 
 	it('should support clone() method', () => {
-		let body = resumer().queue('a=1').end();
-		body = body.pipe(new stream.PassThrough());
+		let body = stream.Readable.from('a=1');
 		const res = new Response(body, {
 			headers: {
 				a: '1'
@@ -131,8 +127,7 @@ describe('Response', () => {
 	});
 
 	it('should support stream as body', () => {
-		let body = resumer().queue('a=1').end();
-		body = body.pipe(new stream.PassThrough());
+		const body = stream.Readable.from('a=1');
 		const res = new Response(body);
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');

--- a/test/response.js
+++ b/test/response.js
@@ -1,3 +1,5 @@
+/* eslint-disable node/no-unsupported-features/node-builtins */
+
 import * as stream from 'stream';
 import chai from 'chai';
 import stringToArrayBuffer from 'string-to-arraybuffer';
@@ -104,7 +106,7 @@ describe('Response', () => {
 	});
 
 	it('should support clone() method', () => {
-		let body = stream.Readable.from('a=1');
+		const body = stream.Readable.from('a=1');
 		const res = new Response(body, {
 			headers: {
 				a: '1'


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix

While working on #210 I went into a particular interpretation of fetch redirect step 9.

[fetch standard](https://fetch.spec.whatwg.org/#http-redirect-fetch):

```
If actualResponse’s status is not 303, request’s body is non-null, and request’s body’s source is null, then return a network error.
```

However, our source instead of body _source_ is checking created `Request.body`. This PR fixes that fact.
This is also important due to fact that we may (_want_) convert the body to a stream internally, so, we actually must check body source here.

In addition, well-outdated test dependency `resumer@0.0.0` was replaced with native `Readable.from`.

In addition, while doing the above replacement, the _hacky_ test for `Buffer.concat` failure was replaced with the correct implementation of the stream that can't be concatenated into a buffer.

This PR also bumps Node.JS minimum version to 10.17 from 10.16 (will also be required for #603 and for #210).