### PR TITLE
Add a missing method when checking if an object is a spec-compliant `FormData` object

### DIFF
--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -57,6 +57,7 @@ export function isFormData(object) {
 		typeof object.set === 'function' &&
 		typeof object.get === 'function' &&
 		typeof object.getAll === 'function' &&
+		typeof object.has === 'function' &&
 		typeof object.delete === 'function' &&
 		typeof object.keys === 'function' &&
 		typeof object.values === 'function' &&


### PR DESCRIPTION
MDN: https://developer.mozilla.org/en-US/docs/Web/API/FormData/has]
Spec: https://xhr.spec.whatwg.org/#dom-formdata-has