### PR TITLE
Allow Mocha tests to be run in parallel

### DIFF
--- a/test/headers.js
+++ b/test/headers.js
@@ -1,5 +1,8 @@
 import {Headers} from '../src/index.js';
 import chai from 'chai';
+import chaiIterator from 'chai-iterator';
+
+chai.use(chaiIterator);
 
 const {expect} = chai;
 

--- a/test/main.js
+++ b/test/main.js
@@ -48,17 +48,6 @@ chai.use(chaiString);
 chai.use(chaiTimeout);
 const {expect} = chai;
 
-const local = new TestServer();
-const base = `http://${local.hostname}:${local.port}/`;
-
-before(done => {
-	local.start(done);
-});
-
-after(done => {
-	local.stop(done);
-});
-
 function streamToPromise(stream, dataHandler) {
 	return new Promise((resolve, reject) => {
 		stream.on('data', (...args) => {
@@ -72,6 +61,18 @@ function streamToPromise(stream, dataHandler) {
 }
 
 describe('node-fetch', () => {
+	const local = new TestServer();
+	let base;
+
+	before(async () => {
+		await local.start();
+		base = `http://${local.hostname}:${local.port}/`;
+	});
+
+	after(async () => {
+		return local.stop();
+	});
+
 	it('should return a promise', () => {
 		const url = `${base}hello`;
 		const p = fetch(url);
@@ -2120,9 +2121,9 @@ describe('node-fetch', () => {
 		expect(extractContentType(null)).to.be.null;
 	});
 
-	it('should encode URLs as UTF-8', () => {
+	it('should encode URLs as UTF-8', async () => {
 		const url = `${base}möbius`;
-
-		fetch(url).then(res => expect(res.url).to.equal(`${base}m%C3%B6bius`));
+		const res = await fetch(url);
+		expect(res.url).to.equal(`${base}m%C3%B6bius`);
 	});
 });

--- a/test/request.js
+++ b/test/request.js
@@ -12,10 +12,19 @@ import {Request} from '../src/index.js';
 
 const {expect} = chai;
 
-const local = new TestServer();
-const base = `http://${local.hostname}:${local.port}/`;
-
 describe('Request', () => {
+	const local = new TestServer();
+	let base;
+
+	before(async () => {
+		await local.start();
+		base = `http://${local.hostname}:${local.port}/`;
+	});
+
+	after(async () => {
+		return local.stop();
+	});
+
 	it('should have attributes conforming to Web IDL', () => {
 		const request = new Request('https://github.com/');
 		const enumerableProperties = [];

--- a/test/response.js
+++ b/test/response.js
@@ -8,10 +8,19 @@ import TestServer from './utils/server.js';
 
 const {expect} = chai;
 
-const local = new TestServer();
-const base = `http://${local.hostname}:${local.port}/`;
-
 describe('Response', () => {
+	const local = new TestServer();
+	let base;
+
+	before(async () => {
+		await local.start();
+		base = `http://${local.hostname}:${local.port}/`;
+	});
+
+	after(async () => {
+		return local.stop();
+	});
+
 	it('should have attributes conforming to Web IDL', () => {
 		const res = new Response();
 		const enumerableProperties = [];

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -1,12 +1,11 @@
 import http from 'http';
 import zlib from 'zlib';
 import Busboy from 'busboy';
+import {once} from 'events';
 
 export default class TestServer {
 	constructor() {
 		this.server = http.createServer(this.router);
-		this.port = 30001;
-		this.hostname = 'localhost';
 		// Node 8 default keepalive timeout is 5000ms
 		// make it shorter here as we want to close server quickly at the end of tests
 		this.server.keepAliveTimeout = 1000;
@@ -18,12 +17,22 @@ export default class TestServer {
 		});
 	}
 
-	start(cb) {
-		this.server.listen(this.port, this.hostname, cb);
+	async start() {
+		this.server.listen(0, 'localhost');
+		return once(this.server, 'listening');
 	}
 
-	stop(cb) {
-		this.server.close(cb);
+	async stop() {
+		this.server.close();
+		return once(this.server, 'close');
+	}
+
+	get port() {
+		return this.server.address().port;
+	}
+
+	get hostname() {
+		return 'localhost';
 	}
 
 	mockResponse(responseHandler) {


### PR DESCRIPTION
This PR fixes our test suite to allow it to run in parallel with new mocha 8 feature:
`npx mocha --parallel`

It doesn't switch to this mode by default due to the fact that at the moment nor `c8` nor `nyc` can collect test coverage in this mode.

Basically this PR makes the test server to bind to a random port (0) instead of fixed one and removes the use of mocha _root hooks_.
One test was refactored into an async function because for some reason it was failing in parallel mode otherwise.

There are no speed improvements right now from running tests in parallel, mostly due to the fact that our current test suite is the monolith of one file, but it will/may improve both with mocha improvements and out tests de-composition, so, it's nice to have:

```sh
mocha --reporter=dot 
212 passing (2s)

# vs
mocha --parallel --reporter=dot
212 passing (3s)
```

Partially deprecates/helps for  #832 / #833 