### PR TITLE
chore: remove `string-to-arraybuffer` test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
 		"p-timeout": "^3.2.0",
 		"parted": "^0.1.1",
 		"rollup": "^2.15.0",
-		"string-to-arraybuffer": "^1.0.2",
 		"tsd": "^0.11.0",
 		"xo": "^0.32.0"
 	},

--- a/test/main.js
+++ b/test/main.js
@@ -7,13 +7,13 @@ import stream from 'stream';
 import path from 'path';
 import {lookup} from 'dns';
 import vm from 'vm';
+import {TextEncoder} from 'util';
 import chai from 'chai';
 import chaiPromised from 'chai-as-promised';
 import chaiIterator from 'chai-iterator';
 import chaiString from 'chai-string';
 import FormData from 'form-data';
 import FormDataNode from 'formdata-node';
-import stringToArrayBuffer from 'string-to-arraybuffer';
 import delay from 'delay';
 import AbortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
 import AbortController2 from 'abort-controller';
@@ -1125,10 +1125,11 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBuffer body', () => {
+		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: stringToArrayBuffer('Hello, world!\n')
+			body: encoder.encode('Hello, world!\n').buffer
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
@@ -1155,10 +1156,11 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (Uint8Array) body', () => {
+		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: new Uint8Array(stringToArrayBuffer('Hello, world!\n'))
+			body: encoder.encode('Hello, world!\n')
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
@@ -1170,10 +1172,11 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (DataView) body', () => {
+		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: new DataView(stringToArrayBuffer('Hello, world!\n'))
+			body: new DataView(encoder.encode('Hello, world!\n').buffer)
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
@@ -1200,10 +1203,11 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (Uint8Array, offset, length) body', () => {
+		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: new Uint8Array(stringToArrayBuffer('Hello, world!\n'), 7, 6)
+			body: encoder.encode('Hello, world!\n').subarray(7, 13)
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');

--- a/test/request.js
+++ b/test/request.js
@@ -1,11 +1,12 @@
 
 import stream from 'stream';
 import http from 'http';
+import {TextEncoder} from 'util';
+
 import AbortController from 'abort-controller';
 import chai from 'chai';
 import FormData from 'form-data';
 import Blob from 'fetch-blob';
-import stringToArrayBuffer from 'string-to-arraybuffer';
 
 import TestServer from './utils/server.js';
 import {Request} from '../src/index.js';
@@ -235,9 +236,10 @@ describe('Request', () => {
 	});
 
 	it('should support ArrayBuffer as body', () => {
+		const encoder = new TextEncoder();
 		const request = new Request(base, {
 			method: 'POST',
-			body: stringToArrayBuffer('a=1')
+			body: encoder.encode('a=1').buffer
 		});
 		return request.text().then(result => {
 			expect(result).to.equal('a=1');
@@ -245,9 +247,10 @@ describe('Request', () => {
 	});
 
 	it('should support Uint8Array as body', () => {
+		const encoder = new TextEncoder();
 		const request = new Request(base, {
 			method: 'POST',
-			body: new Uint8Array(stringToArrayBuffer('a=1'))
+			body: encoder.encode('a=1')
 		});
 		return request.text().then(result => {
 			expect(result).to.equal('a=1');
@@ -255,9 +258,10 @@ describe('Request', () => {
 	});
 
 	it('should support DataView as body', () => {
+		const encoder = new TextEncoder();
 		const request = new Request(base, {
 			method: 'POST',
-			body: new DataView(stringToArrayBuffer('a=1'))
+			body: new DataView(encoder.encode('a=1').buffer)
 		});
 		return request.text().then(result => {
 			expect(result).to.equal('a=1');

--- a/test/response.js
+++ b/test/response.js
@@ -1,7 +1,7 @@
 
 import * as stream from 'stream';
+import {TextEncoder} from 'util';
 import chai from 'chai';
-import stringToArrayBuffer from 'string-to-arraybuffer';
 import Blob from 'fetch-blob';
 import {Response} from '../src/index.js';
 import TestServer from './utils/server.js';
@@ -150,7 +150,8 @@ describe('Response', () => {
 	});
 
 	it('should support ArrayBuffer as body', () => {
-		const res = new Response(stringToArrayBuffer('a=1'));
+		const encoder = new TextEncoder();
+		const res = new Response(encoder.encode('a=1'));
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});
@@ -164,14 +165,16 @@ describe('Response', () => {
 	});
 
 	it('should support Uint8Array as body', () => {
-		const res = new Response(new Uint8Array(stringToArrayBuffer('a=1')));
+		const encoder = new TextEncoder();
+		const res = new Response(encoder.encode('a=1'));
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});
 	});
 
 	it('should support DataView as body', () => {
-		const res = new Response(new DataView(stringToArrayBuffer('a=1')));
+		const encoder = new TextEncoder();
+		const res = new Response(new DataView(encoder.encode('a=1').buffer));
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});


### PR DESCRIPTION
This PR removes external test dependency `string-to-arraybuffer` in favor of Node.js built-in `util.TextEncoder` available since Node 8.30