### PR TITLE
chore: remove `parted` test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
 		"formdata-node": "^2.2.0",
 		"mocha": "^8.0.0",
 		"p-timeout": "^3.2.0",
-		"parted": "^0.1.1",
 		"rollup": "^2.15.0",
 		"string-to-arraybuffer": "^1.0.2",
 		"tsd": "^0.11.0",


### PR DESCRIPTION
Looks like a bad merge, `parted` was replaced by `busboy` at #603 and not in use in this project anymore.