### PR TITLE
chore: remove `p-timeout` test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"form-data": "^3.0.0",
 		"formdata-node": "^2.2.0",
 		"mocha": "^8.0.0",
-		"p-timeout": "^3.2.0",
 		"parted": "^0.1.1",
 		"rollup": "^2.15.0",
 		"string-to-arraybuffer": "^1.0.2",

--- a/test/utils/chai-timeout.js
+++ b/test/utils/chai-timeout.js
@@ -1,11 +1,8 @@
-import pTimeout from 'p-timeout';
-
 export default ({Assertion}, utils) => {
 	utils.addProperty(Assertion.prototype, 'timeout', async function () {
-		let timeouted = false;
-		await pTimeout(this._obj, 150, () => {
-			timeouted = true;
-		});
+		const timeouted = await Promise.race([this._obj.then(() => false), new Promise(resolve => {
+			setTimeout(() => resolve(true), 150);
+		})]);
 		return this.assert(
 			timeouted,
 			'expected promise to timeout but it was resolved',


### PR DESCRIPTION
[p-timeout](https://github.com/sindresorhus/p-timeout/blob/master/index.js) may be a good library for some complicated use case, but it's not small (57 LOC + 1 dependency) and we use it just at one place - to implement our `chai-timeout` that can be trivially implemented without an external dependency.

