### PR TITLE
fix: add missing exports subpath "./package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
-		"import": "./src/index.js",
-		"require": "./dist/index.cjs"
+		".": {
+			"import": "./src/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./package.json": "./package.json"
 	},
 	"files": [
 		"src",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
`require('node-fetch/package.json')` fails because package exports missing "./package.json" sub-path.
My repo which using nuxt needs to read package.json.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
It's my first time to send a PR to node-fetch, so please let me know if there is anything to fix.