### PR TITLE
Use generic typings for response.json()

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -100,7 +100,7 @@ type BodyInit =
 	| NodeJS.ReadableStream
 	| string;
 type BodyType = { [K in keyof Body]: Body[K] };
-declare class Body {
+declare class Body<T = unknown> {
 	constructor(body?: BodyInit, opts?: { size?: number });
 
 	readonly body: NodeJS.ReadableStream | null;
@@ -110,7 +110,7 @@ declare class Body {
 	buffer(): Promise<Buffer>;
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;
-	json(): Promise<unknown>;
+	json(): Promise<T>;
 	text(): Promise<string>;
 }
 
@@ -142,7 +142,7 @@ declare class Request extends Body {
 	clone(): Request;
 }
 
-declare class Response extends Body {
+declare class Response<T = unknown> extends Body<T> {
 	constructor(body?: BodyInit | null, init?: ResponseInit);
 
 	readonly headers: Headers;
@@ -171,7 +171,7 @@ declare class AbortError extends Error {
 }
 
 
-declare function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
+declare function fetch<T = unknown>(url: RequestInfo, init?: RequestInit): Promise<Response<T>>;
 declare class fetch {
 	static default: typeof fetch;
 }


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
made response json() generic

```typescript
export interface User {
  id: string;
}

async function getUser(id: string) {
  const response = await fetch<User>(`http://localhost/api/user/${id}`);
  return response.json(); // Promise<User>
}
```

no breaking changes. generic is optional

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
