### PR TITLE
Handle zero-length OK deflate responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,13 @@ export default function fetch(url, opts) {
 					response = new Response(body, response_options);
 					resolve(response);
 				});
+				raw.on('end', () => {
+					// some old IIS servers return zero-length OK deflate responses, so 'data' is never emitted.
+					if (!response) {
+						response = new Response(body, response_options);
+						resolve(response);
+					}
+				})
 				return;
 			}
 

--- a/test/server.js
+++ b/test/server.js
@@ -115,6 +115,13 @@ export default class TestServer {
 			});
 		}
 
+		if (p === '/empty/deflate') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/plain');
+			res.setHeader('Content-Encoding', 'deflate');
+			res.end();
+		}
+
 		if (p === '/sdch') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'text/plain');

--- a/test/test.js
+++ b/test/test.js
@@ -679,6 +679,17 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should handle empty deflate response', function() {
+		const url = `${base}empty/deflate`;
+		return fetch(url).then(res => {
+			expect(res.headers.get('content-type')).to.equal('text/plain');
+			return res.text().then(result => {
+				expect(result).to.be.a('string');
+				expect(result).to.be.empty;
+			});
+		});
+	});
+
 	it('should decompress brotli response', function() {
 		if(typeof zlib.createBrotliDecompress !== 'function') this.skip();
 		const url = `${base}brotli`;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make?**

This fixes an issue where older ISS servers (Definitely 7.5, but I can’t rule out other versions), could respond with a zero-length OK deflate response, hanging node-fetch. This was caused by the body stream never emitting a `data` event. A typical problematic response looks something like this:

```http
HTTP/1.1 200 OK
Content-Encoding: deflate
Content-Length: 0
Server: Microsoft-IIS/7.5
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
```

**Is there anything you'd like reviewers to know?**

Our codebase uses node-fetch 2.6.0, but this is still an issue in v3. I’m not sure how to go about patching both branches.