### PR TITLE
Added support for capturing timing information for the request. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 # 2.x release
 
+## v2.6.1
+- Enhance: `Response` object now includes conditional `timings` property.
+
 ## v2.6.0
 
 - Enhance: `options.agent`, it now accepts a function that returns custom http(s).Agent instance based on current URL, see readme for more information.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ The default values are shown after each option key.
     timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies). Signal is recommended instead.
     compress: true,     // support gzip/deflate content encoding. false to disable
     size: 0,            // maximum response body size in bytes. 0 to disable
-    agent: null         // http(s).Agent instance or function that returns an instance (see below)
+    agent: null,        // http(s).Agent instance or function that returns an instance (see below)
+    timings: false      // Set true to include timing information in the response object
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A light-weight module that brings window.fetch to node.js",
   "main": "lib/index",
   "browser": "./browser.js",
@@ -62,5 +62,7 @@
     "string-to-arraybuffer": "^1.0.2",
     "whatwg-url": "^5.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@szmarczak/http-timer": "^4.0.5"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,12 @@ export default function fetch(url, opts) {
 
 		// send request
 		const req = send(options);
+
+		// add request timings
+		if (opts && opts.timings) {
+			let timer = require('@szmarczak/http-timer');
+			timer(req);
+		}
 		let reqTimeout;
 
 		if (signal) {
@@ -201,7 +207,8 @@ export default function fetch(url, opts) {
 				headers: headers,
 				size: request.size,
 				timeout: request.timeout,
-				counter: request.counter
+				counter: request.counter,
+				timings: res.timings
 			};
 
 			// HTTP-network fetch step 12.1.1.3

--- a/src/response.js
+++ b/src/response.js
@@ -24,6 +24,7 @@ const STATUS_CODES = http.STATUS_CODES;
  */
 export default class Response {
 	constructor(body = null, opts = {}) {
+		this.timings = opts.timings;
 		Body.call(this, body, opts);
 
 		const status = opts.status || 200;

--- a/test/test.js
+++ b/test/test.js
@@ -2869,4 +2869,22 @@ describe('external encoding', () => {
 			});
 		});
 	});
+  
+	describe('timings', function() {
+		it('should not return timings if not configured', function() {
+			const url = `${base}hello`;
+			return fetch(url)
+			.then(res => {
+				expect(res.timings).to.be.undefined;
+			});
+		});
+		
+		it('should return timings if configured', function() {
+			const url = `${base}hello`;
+			return fetch(url, {timings: true})
+			.then(res => {
+				expect(res).to.be.an.instanceOf(Object);
+			});
+		});
+	});
 });


### PR DESCRIPTION


<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

The legacy request npm package provided the capability to return timing related data to the caller in the response. For example:

`phases: {
     wait: 1,
     dns: 53,
     tcp: 156,
     request: 313,
     firstByte: 153,
     download: 2,
     total: 678
   }`

We need this functionality and there is not a good away to add this, even with using shimmer. I have added this functionality in this PR.

To implement this, I used the package from: https://www.npmjs.com/package/@szmarczak/http-timer which includes 1 transitive dependency: https://www.npmjs.com/package/defer-to-connect.

Let me know if you have another way to include the timing data that I have not considered.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
