### PR TITLE
Allow passing agent option as an object 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,13 @@ export default function fetch(url, opts) {
 		const request = new Request(url, opts);
 		const options = getNodeRequestOptions(request);
 
-		const send = (options.protocol === 'https:' ? https : http).request;
+    const protocol = (options.protocol === 'https:' ? https : http)
+		const send = protocol.request;
+
+ 		if (options.agent && typeof options.agent === 'object' && !(options.agent instanceof http.Agent)) {
+ 			options.agent = new protocol.Agent(options.agent)
+ 		}
+
 		const { signal } = request;
 		let response = null;
 

--- a/test/test.js
+++ b/test/test.js
@@ -1775,6 +1775,20 @@ describe('node-fetch', () => {
 		});
 	});
 
+  it('should create http.Agent class if options.agent is provided as an object', function() {
+		const url = `${base}inspect`;
+ 		const opts = {
+ 			agent: {
+ 				keepAlive: true
+ 			}
+ 		};
+ 		return fetch(url, opts).then(res => {
+ 			return res.json();
+ 		}).then(res => {
+ 			expect(res.headers['connection']).to.equal('keep-alive');
+ 		});
+ 	});
+
 	it('should send request with connection keep-alive if agent is provided', function() {
 		const url = `${base}inspect`;
 		const opts = {


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

See https://github.com/node-fetch/node-fetch/pull/236#issue-106457886

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Reinstated changes in #236 

**Which issue (if any) does this pull request address?**
We're using Ember Fastboot. We need to change our Fastboot URL to use HTTPS instead of HTTP. Without this change we experience SSL errors and are unable to proceed with updating our Fastboot URL.

**Is there anything you'd like reviewers to know?**
I'm also planning on creating a PR into master, due to internal reasons we are unable to upgrade to node-fetch@3 and so need the change to go both into 2.6.0 and master.