### PR TITLE
fix: Add missing insecureHTTPParser in RequestInit interface

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -85,6 +85,7 @@ interface RequestInit {
 	protocol?: string;
 	size?: number;
 	highWaterMark?: number;
+	insecureHTTPParser?: boolean;
 }
 
 interface ResponseInit {


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**
`insecureHTTPParser` was missing from the typings. This pull request adds it in.

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Added `insecureHTTPParser` to the `RequestInit` interface.

**Which issue (if any) does this pull request address?**
#953.

**Is there anything you'd like reviewers to know?**
No.