### PR TITLE
Handle zero-length OK deflate responses (master)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,11 @@ export default async function fetch(url, options_) {
 			if (codings === 'deflate' || codings === 'x-deflate') {
 				// Handle the infamous raw deflate response from old servers
 				// a hack for old IIS and Apache servers
-				const raw = pump(response_, new PassThrough(), reject);
+				const raw = pump(response_, new PassThrough(), err => {
+					if (err) {
+						reject(err);
+					}
+				});
 				raw.once('data', chunk => {
 					// See http://stackoverflow.com/questions/37519828
 					body = (chunk[0] & 0x0F) === 0x08 ? pump(body, zlib.createInflate(), reject) : pump(body, zlib.createInflateRaw(), reject);

--- a/src/index.js
+++ b/src/index.js
@@ -235,9 +235,9 @@ export default async function fetch(url, options_) {
 				});
 			}
 
-			let body = pump(response_, new PassThrough(), err => {
-				if (err) {
-					reject(err);
+			let body = pump(response_, new PassThrough(), error => {
+				if (error) {
+					reject(error);
 				}
 			});
 			// see https://github.com/nodejs/node/pull/29376
@@ -285,9 +285,9 @@ export default async function fetch(url, options_) {
 
 			// For gzip
 			if (codings === 'gzip' || codings === 'x-gzip') {
-				body = pump(body, zlib.createGunzip(zlibOptions), err => {
-					if (err) {
-						reject(err);
+				body = pump(body, zlib.createGunzip(zlibOptions), error => {
+					if (error) {
+						reject(error);
 					}
 				});
 				response = new Response(body, responseOptions);
@@ -299,23 +299,23 @@ export default async function fetch(url, options_) {
 			if (codings === 'deflate' || codings === 'x-deflate') {
 				// Handle the infamous raw deflate response from old servers
 				// a hack for old IIS and Apache servers
-				const raw = pump(response_, new PassThrough(), err => {
-					if (err) {
-						reject(err);
+				const raw = pump(response_, new PassThrough(), error => {
+					if (error) {
+						reject(error);
 					}
 				});
 				raw.once('data', chunk => {
 					// See http://stackoverflow.com/questions/37519828
 					if ((chunk[0] & 0x0F) === 0x08) {
-						body = pump(body, zlib.createInflate(), err => {
-							if (err) {
-								reject(err);
+						body = pump(body, zlib.createInflate(), error => {
+							if (error) {
+								reject(error);
 							}
 						});
 					} else {
-						body = pump(body, zlib.createInflateRaw(), err => {
-							if (err) {
-								reject(err);
+						body = pump(body, zlib.createInflateRaw(), error => {
+							if (error) {
+								reject(error);
 							}
 						});
 					}
@@ -336,9 +336,9 @@ export default async function fetch(url, options_) {
 
 			// For br
 			if (codings === 'br') {
-				body = pump(body, zlib.createBrotliDecompress(), err => {
-					if (err) {
-						reject(err);
+				body = pump(body, zlib.createBrotliDecompress(), error => {
+					if (error) {
+						reject(error);
 					}
 				});
 				response = new Response(body, responseOptions);

--- a/test/main.js
+++ b/test/main.js
@@ -946,6 +946,17 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should handle empty deflate response', () => {
+		const url = `${base}empty/deflate`;
+		return fetch(url).then(res => {
+			expect(res.headers.get('content-type')).to.equal('text/plain');
+			return res.text().then(result => {
+				expect(result).to.be.a('string');
+				expect(result).to.be.empty;
+			});
+		});
+	});
+
 	it('should decompress brotli response', function () {
 		if (typeof zlib.createBrotliDecompress !== 'function') {
 			this.skip();

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -179,6 +179,13 @@ export default class TestServer {
 			});
 		}
 
+		if (p === '/empty/deflate') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/plain');
+			res.setHeader('Content-Encoding', 'deflate');
+			res.end();
+		}
+
 		if (p === '/sdch') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'text/plain');


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix

**What changes did you make?**

This fixes an issue where older ISS servers (Definitely 7.5, but I can’t rule out other versions), could respond with a zero-length OK deflate response, hanging node-fetch. This was caused by the body stream never emitting a `data` event. A typical problematic response looks something like this:

```http
HTTP/1.1 200 OK
Content-Encoding: deflate
Content-Length: 0
Server: Microsoft-IIS/7.5
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
```

**Is there anything you'd like reviewers to know?**

This is the master counterpart to the 2.x PR #903
I had to tweak it a bit compared to the 2.x version because `pump` would incorrectly reject on empty responses. 

- fix #1442
- fix #922
- fix #903