### PR TITLE
Remove automatic title assignment from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: 🐞 Bug report
 about: Create a report to help us improve node-fetch
-title: "Bug: "
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,10 +1,7 @@
 ---
 name: '✨ Feature Request'
 about: Suggest an idea or feature
-title: 'Feature request: '
 labels: feature
-assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/support-or-usage.md
+++ b/.github/ISSUE_TEMPLATE/support-or-usage.md
@@ -1,10 +1,7 @@
 ---
 name: "\U0001F914 Support or Usage Question"
 about: Get help using node-fetch
-title: 'Question: '
 labels: question
-assignees: ''
-
 ---
 
 <!--


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain:

The default `title` value in our issue template is causing too much default title issues.

We want to make issue submission easy but not that easy, leaving them blank should force issue submitter to type something more useful.

Plus we had automate label assignment already, the heading is mostly superfluous. 

**What changes did you make? (provide an overview)**

Issue templates

**Which issue (if any) does this pull request address?**

Issue titles

**Is there anything you'd like reviewers to know?**

Please review and merge, hope I didn't break anything :)