### PR TITLE
Support instances of `EventTarget` as a `signal`

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -83,7 +83,7 @@ export default class Request extends Body {
 		}
 
 		if (signal !== null && !isAbortSignal(signal)) {
-			throw new TypeError('Expected signal to be an instanceof AbortSignal');
+			throw new TypeError('Expected signal to be an instanceof AbortSignal or EventTarget');
 		}
 
 		this[INTERNALS] = {

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -74,8 +74,10 @@ export function isFormData(object) {
  */
 export const isAbortSignal = object => {
 	return (
-		typeof object === 'object' &&
-		object[NAME] === 'AbortSignal'
+		typeof object === 'object' && (
+			object[NAME] === 'AbortSignal' ||
+			object[NAME] === 'EventTarget'
+		)
 	);
 };
 

--- a/test/main.js
+++ b/test/main.js
@@ -1021,7 +1021,7 @@ describe('node-fetch', () => {
 		return result;
 	});
 
-	it('should throw a TypeError if a signal is not of type AbortSignal', () => {
+	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
 		return Promise.all([
 			expect(fetch(`${base}inspect`, {signal: {}}))
 				.to.be.eventually.rejected


### PR DESCRIPTION
Node has added its own AbortController in 15.0.0. The AbortController signal
inherits from EventTarget. This changes the check to also accept signals of
type EventTarget.

https://nodejs.org/docs/latest-v15.x/api/globals.html#globals_class_abortsignal

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

Modified the `isAbortSignal` check to accept `EventTarget` as well.

**Which issue (if any) does this pull request address?**

Incompatibility with the new node `AbortController`