### PR TITLE
[docs] Fix incorrect code indentation in README docs for AbortSignal

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ const timeout = setTimeout(() => {
 		useData(data);
 	} catch (error) {
 		if (error.name === 'AbortError') {
-            console.log('request was aborted');
+			console.log('request was aborted');
 		}
 	} finally {
 		clearTimeout(timeout);

--- a/src/request.js
+++ b/src/request.js
@@ -16,9 +16,9 @@ import {getSearch} from './utils/get-search.js';
 const INTERNALS = Symbol('Request internals');
 
 /**
- * Check if `obj` is an instance of Request.
+ * Check if `object` is an instance of Request.
  *
- * @param  {*} obj
+ * @param  {*} object
  * @return {boolean}
  */
 const isRequest = object => {
@@ -149,7 +149,7 @@ Object.defineProperties(Request.prototype, {
 /**
  * Convert a Request to Node.js http request options.
  *
- * @param   Request  A Request instance
+ * @param   request  A Request instance
  * @return  Object   The options object to be passed to http.request
  */
 export const getNodeRequestOptions = request => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

The README file has incorrect indentation for the [Request cancellation with AbortSignal](https://github.com/node-fetch/node-fetch#request-cancellation-with-abortsignal) because of mixed tabs and spaces.

<img width="414" alt="Screen Shot 2020-11-10 at 9 32 24 AM" src="https://user-images.githubusercontent.com/9907304/98711338-b616fd00-2339-11eb-88d6-650cef5ffa9b.png">

This PR also fixes two small issues with the JSDoc comments in the `request.js` file where the parameter and comment did not match.