### PR TITLE
Throw a `TypeError` on an invalid redirect option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ export default async function fetch(url, options_) {
 					}
 
 					default:
-					// Do nothing
+						return reject(new TypeError(`Redirect option '${request.redirect}' is not a valid value of RequestRedirect`));
 				}
 			}
 

--- a/test/main.js
+++ b/test/main.js
@@ -512,6 +512,19 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should throw a TypeError on an invalid redirect option', () => {
+		const url = `${base}redirect/301`;
+		const options = {
+			redirect: 'foobar'
+		};
+		return fetch(url, options).then(() => {
+			expect.fail();
+		}, error => {
+			expect(error).to.be.an.instanceOf(TypeError);
+			expect(error.message).to.equal('Redirect option \'foobar\' is not a valid value of RequestRedirect');
+		});
+	});
+
 	it('should set redirected property on response when redirect', () => {
 		const url = `${base}redirect/301`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

If an invalid `redirect` option is passed and a redirect does occur, the default case now throws a `TypeError`.

**Which issue (if any) does this pull request address?**

none

**Is there anything you'd like reviewers to know?**

First, I consider this a backwards-incompatible change since the current code would simply ignore a redirection altogether with an invalid `redirect` value.  If back-porting is being considered for any changes, I recommend this **not** be considered for back-porting to v2.

Justification:

1. The Fetch specification defines [RequestRedirect](https://fetch.spec.whatwg.org/#requestredirect) as an enum; therefore, other values should not be allowed.
2. It seems more reasonable to give a programmer a good error message rather than simply ignoring a redirection.
3. Chrome and Firefox both throw a `TypeError` with invalid values:

Chrome:
```js
let res = await fetch('https://google.com', { redirect: 'foobar' });
```
    > Uncaught TypeError: Failed to execute 'fetch' on 'Window': The provided value 'foobar' is not a valid enum value of type RequestRedirect.

Firefox:
```js
let res = await fetch('https://google.com', { redirect: 'foobar' });
```
    > Uncaught (in promise) TypeError: Window.fetch: 'foobar' (value of 'redirect' member of RequestInit) is not a valid value for enumeration RequestRedirect.
