### PR TITLE
Compute total bytes in Body constructor when possible

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -354,7 +354,7 @@ export const getTotalBytes = request => {
 
 	// Body is a spec-compliant FormData
 	if (isFormData(body)) {
-		return getFormDataLength(request[INTERNALS].boundary);
+		return getFormDataLength(body, request[INTERNALS].boundary);
 	}
 
 	// Body is stream

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -38,6 +38,7 @@ export const isBlob = object => {
 		object &&
 		typeof object === 'object' &&
 		typeof object.arrayBuffer === 'function' &&
+		typeof object.size === 'number' &&
 		typeof object.type === 'string' &&
 		typeof object.stream === 'function' &&
 		typeof object.constructor === 'function' &&

--- a/test/main.js
+++ b/test/main.js
@@ -2287,7 +2287,7 @@ describe('node-fetch', () => {
 		});
 
 		const formBody = new FormData();
-		formBody.append('a', '1');
+		formBody.append(...bodyContent.split('='));
 		const formRequest = new Request(url, {
 			method: 'POST',
 			body: formBody,
@@ -2315,7 +2315,7 @@ describe('node-fetch', () => {
 
 		expect(getTotalBytes(streamRequest)).to.be.null;
 		expect(getTotalBytes(blobRequest)).to.equal(blobBody.size);
-		expect(getTotalBytes(formRequest)).to.not.be.null;
+		expect(getTotalBytes(formRequest)).to.equal(formBody.getLengthSync());
 		expect(getTotalBytes(bufferRequest)).to.equal(bufferBody.length);
 		expect(getTotalBytes(stringRequest)).to.equal(bodyContent.length);
 		expect(getTotalBytes(nullRequest)).to.equal(0);

--- a/test/main.js
+++ b/test/main.js
@@ -1536,6 +1536,7 @@ describe('node-fetch', () => {
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
 			expect(res.headers['content-type']).to.startWith('multipart/form-data');
+			expect(res.headers['content-length']).to.be.a('string');
 			expect(res.body).to.contain('field=');
 			expect(res.body).to.contain('file=');
 		});


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

When a `Body` is constructed from something other than a stream, it now computes the `totalBytes` in the constructor instead of with `getTotalBytes`.  This fixes a few issues with the construction of bodies from `FormData` objects.

This change also sets the 

**Which issue (if any) does this pull request address?**

#1045

**Is there anything you'd like reviewers to know?**

no