### PR TITLE
Fix missing return after reject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,13 +116,7 @@ export default async function fetch(url, options_) {
 					case 'manual':
 						// Node-fetch-specific step: make manual redirect a bit easier to use by setting the Location header value to the resolved URL.
 						if (locationURL !== null) {
-							// Handle corrupted header
-							try {
-								headers.set('Location', locationURL);
-								/* c8 ignore next 3 */
-							} catch (error) {
-								reject(error);
-							}
+							headers.set('Location', locationURL);
 						}
 
 						break;

--- a/test/main.js
+++ b/test/main.js
@@ -456,6 +456,18 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should support redirect mode, manual flag, broken Location header', () => {
+		const url = `${base}redirect/bad-location`;
+		const options = {
+			redirect: 'manual'
+		};
+		return fetch(url, options).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.status).to.equal(301);
+			expect(res.headers.get('location')).to.equal(`${base}redirect/%C3%A2%C2%98%C2%83`);
+		});
+	});
+
 	it('should support redirect mode, error flag', () => {
 		const url = `${base}redirect/301`;
 		const options = {

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -288,6 +288,11 @@ export default class TestServer {
 			res.end();
 		}
 
+		if (p === '/redirect/bad-location') {
+			res.socket.write('HTTP/1.1 301\r\nLocation: ☃\r\nContent-Length: 0\r\n');
+			res.socket.end('\r\n');
+		}
+
 		if (p === '/error/400') {
 			res.statusCode = 400;
 			res.setHeader('Content-Type', 'text/plain');


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

This "fixes" the issue of a missing return after reject (#890) by removing the try/catch and reject altogether.  A bad [Location header is escaped by the URL module](https://github.com/tekwiz/node-fetch/blob/398332cde15a9ef3104f02bc77a49a47d695df7e/src/index.js#L108), so any "corrupted" headers become valid or otherwise cause errors earlier in processing.  The bottom-line is that this call to reject can never happen.

**Which issue (if any) does this pull request address?**

Fixes #890

**Is there anything you'd like reviewers to know?**

no