### PR TITLE
Allow `signal` to be `null` or `undefined`

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -82,7 +82,8 @@ export default class Request extends Body {
 			signal = init.signal;
 		}
 
-		if (signal !== null && !isAbortSignal(signal)) {
+		// eslint-disable-next-line no-eq-null, eqeqeq
+		if (signal != null && !isAbortSignal(signal)) {
 			throw new TypeError('Expected signal to be an instanceof AbortSignal');
 		}
 

--- a/test/main.js
+++ b/test/main.js
@@ -1038,6 +1038,17 @@ describe('node-fetch', () => {
 		]);
 	});
 
+	it('should gracefully handle a nullish signal', () => {
+		return Promise.all([
+			fetch(`${base}hello`, {signal: null}).then(res => {
+				return expect(res.ok).to.be.true;
+			}),
+			fetch(`${base}hello`, {signal: undefined}).then(res => {
+				return expect(res.ok).to.be.true;
+			})
+		]);
+	});
+
 	it('should set default User-Agent', () => {
 		const url = `${base}inspect`;
 		return fetch(url).then(res => res.json()).then(res => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

This allows a falsey `signal` to be ignored.  e.g. 
```
fetch('https://google.com', { signal: undefined })
```

**Which issue (if any) does this pull request address?**

Fixes #1029

**Is there anything you'd like reviewers to know?**

no
