### PR TITLE
Fix premature close with chunked transfer encoding and for async iterators in Node 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,55 @@ if (!response.ok) throw new Error(`unexpected response ${response.statusText}`);
 await streamPipeline(response.body, createWriteStream('./octocat.png'));
 ```
 
+In Node.js 14 you can also use async iterators to read `body`; however, be careful to catch
+errors -- the longer a response runs, the more likely it is to encounter an error.
+
+```js
+const fetch = require('node-fetch');
+
+const response = await fetch('https://httpbin.org/stream/3');
+
+try {
+	for await (const chunk of response.body) {
+		console.dir(JSON.parse(chunk.toString()));
+	}
+} catch (err) {
+	console.error(err.stack);
+}
+```
+
+In Node.js 12 you can also use async iterators to read `body`; however, async iterators with streams
+did not mature until Node.js 14, so you need to do some extra work to ensure you handle errors
+directly from the stream and wait on it response to fully close.
+
+```js
+const fetch = require('node-fetch');
+
+const read = async body => {
+	let error;
+	body.on('error', err => {
+		error = err;
+	});
+
+	for await (const chunk of body) {
+		console.dir(JSON.parse(chunk.toString()));
+	}
+
+	return new Promise((resolve, reject) => {
+		body.on('close', () => {
+			error ? reject(error) : resolve();
+		});
+	});
+};
+
+try {
+	const response = await fetch('https://httpbin.org/stream/3');
+	await read(response.body);
+} catch (err) {
+	console.error(err.stack);
+}
+```
+
 ### Buffer
 
 If you prefer to cache binary data in full, use buffer(). (NOTE: buffer() is a `node-fetch` only API)

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,26 @@ export default async function fetch(url, options_) {
 			response.body.destroy(err);
 		});
 
+		/* c8 ignore next 18 */
+		if (process.version < 'v14') {
+			// Before Node.js 14, pipeline() does not fully support async iterators and does not always
+			// properly handle when the socket close/end events are out of order.
+			request_.on('socket', s => {
+				let endedWithEventsCount;
+				s.prependListener('end', () => {
+					endedWithEventsCount = s._eventsCount;
+				});
+				s.prependListener('close', hadError => {
+					// if end happened before close but the socket didn't emit an error, do it now
+					if (response && endedWithEventsCount < s._eventsCount && !hadError) {
+						const err = new Error('Premature close');
+						err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+						response.body.emit('error', err);
+					}
+				});
+			});
+		}
+
 		request_.on('response', response_ => {
 			request_.setTimeout(0);
 			const headers = fromRawHeaders(response_.rawHeaders);

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,10 @@ export default async function fetch(url, options_) {
 			finalize();
 		});
 
+		fixResponseChunkedTransferBadEnding(request_, err => {
+			response.body.destroy(err);
+		});
+
 		request_.on('response', response_ => {
 			request_.setTimeout(0);
 			const headers = fromRawHeaders(response_.rawHeaders);
@@ -263,5 +267,33 @@ export default async function fetch(url, options_) {
 		});
 
 		writeToStream(request_, request);
+	});
+}
+
+function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+	const LAST_CHUNK = Buffer.from('0\r\n');
+	let socket;
+
+	request.on('socket', s => {
+		socket = s;
+	});
+
+	request.on('response', response => {
+		const {headers} = response;
+		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
+			let properLastChunkReceived = false;
+
+			socket.on('data', buf => {
+				properLastChunkReceived = Buffer.compare(buf.slice(-3), LAST_CHUNK) === 0;
+			});
+
+			socket.prependListener('close', () => {
+				if (!properLastChunkReceived) {
+					const err = new Error('Premature close');
+					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+					errorCallback(err);
+				}
+			});
+		}
 	});
 }

--- a/test/main.js
+++ b/test/main.js
@@ -613,6 +613,24 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should handle network-error in chunked response', () => {
+		const url = `${base}error/premature/chunked`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+
+			const read = async (body) => {
+				const chunks = [];
+				for await (const chunk of body) {
+					chunks.push(chunk);
+				}
+				return chunks;
+			};
+
+			return expect(read(res.body)).to.eventually.be.rejectedWith(Error);
+		});
+	});
+
 	it('should handle DNS-error response', () => {
 		const url = 'http://domain.invalid';
 		return expect(fetch(url)).to.eventually.be.rejected

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -323,6 +323,23 @@ export default class TestServer {
 			}, 100);
 		}
 
+		if (p === '/error/premature/chunked') {
+			res.writeHead(200, {
+				'content-type': 'application/json',
+				'transfer-encoding': 'chunked'
+			});
+
+			res.write(`${JSON.stringify({ data: 'hi' })}\n`);
+
+			setTimeout(() => {
+				res.write(`${JSON.stringify({ data: 'bye' })}\n`);
+			}, 100);
+
+			setTimeout(() => {
+				res.destroy()
+			}, 200);
+		}
+
 		if (p === '/error/json') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -325,19 +325,19 @@ export default class TestServer {
 
 		if (p === '/error/premature/chunked') {
 			res.writeHead(200, {
-				'content-type': 'application/json',
-				'transfer-encoding': 'chunked'
+				'Content-Type': 'application/json',
+				'Transfer-Encoding': 'chunked'
 			});
 
-			res.write(`${JSON.stringify({ data: 'hi' })}\n`);
+			res.write(`${JSON.stringify({data: 'hi'})}\n`);
 
 			setTimeout(() => {
-				res.write(`${JSON.stringify({ data: 'bye' })}\n`);
-			}, 100);
-
-			setTimeout(() => {
-				res.destroy()
+				res.write(`${JSON.stringify({data: 'bye'})}\n`);
 			}, 200);
+
+			setTimeout(() => {
+				res.destroy();
+			}, 400);
 		}
 
 		if (p === '/error/json') {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

re. 47b00e179dd8a450f3fffd9ac22d148197a09229: For responses using chunked `Transfer-Encoding` without a `Content-Length`, this adds a check at the socket's `close` event to verify that the last bytes received were the final chunk bytes, i.e. `0\r\n`.  If not, it creates a `Premature close` error and sends it to `response.body.destroy()`.  Certain network errors evidently bypass the HTTP parser's error handling resulting in silent failures.  @davidje13 confirmed fix in #739 https://github.com/node-fetch/node-fetch/issues/739#issuecomment-754173198.

re. 13cdcf3d2fa514b76d60b5e73b5a8602e7d336b7: Before Node.js 14, pipeline() does not fully support async iterators and does not always properly handle when the socket close/end events are out of order. This fix emits a `Premature close` error if the socket's readable `end` event occurs before the writable `close` event.

re. 9cf8c1820e4f72739b8921cc7cec6e2f0e8ccfae: Usage of async iterators for both Node.js 12 and 14 is added to the README.

**Which issue (if any) does this pull request address?**

#739 #766 #968 #1055 #1056 and possibly #736

**Is there anything you'd like reviewers to know?**
