### PR TITLE
Fully test both AbortController implementations, Bump abortcontroller-polyfill to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "abortcontroller-polyfill": "^1.5.0",
+    "abortcontroller-polyfill": "^1.7.1",
     "busboy": "^0.3.1",
     "c8": "^7.3.0",
     "chai": "^4.2.0",

--- a/test/main.js
+++ b/test/main.js
@@ -15,10 +15,9 @@ import chaiString from 'chai-string';
 import FormData from 'form-data';
 import FormDataNode from 'formdata-node';
 import delay from 'delay';
-import AbortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
-import AbortController2 from 'abort-controller';
-
-const {AbortController} = AbortControllerPolyfill;
+import AbortControllerMysticatea from 'abort-controller';
+import abortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
+const AbortControllerPolyfill = abortControllerPolyfill.AbortController;
 
 // Test subjects
 import Blob from 'fetch-blob';
@@ -853,198 +852,234 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should support request cancellation with signal', function () {
-		this.timeout(500);
-		const controller = new AbortController();
-		const controller2 = new AbortController2();
+	const testAbortController = (name, buildAbortController, moreTests = null) => {
+		describe(`AbortController (${name})`, () => {
+			let controller;
 
-		const fetches = [
-			fetch(`${base}timeout`, {signal: controller.signal}),
-			fetch(`${base}timeout`, {signal: controller2.signal}),
-			fetch(
-				`${base}timeout`,
-				{
-					method: 'POST',
-					signal: controller.signal,
-					headers: {
-						'Content-Type': 'application/json',
-						body: JSON.stringify({hello: 'world'})
-					}
-				}
-			)
-		];
-		setTimeout(() => {
-			controller.abort();
-			controller2.abort();
-		}, 100);
-
-		return Promise.all(fetches.map(fetched => expect(fetched)
-			.to.eventually.be.rejected
-			.and.be.an.instanceOf(Error)
-			.and.include({
-				type: 'aborted',
-				name: 'AbortError'
-			})
-		));
-	});
-
-	it('should reject immediately if signal has already been aborted', () => {
-		const url = `${base}timeout`;
-		const controller = new AbortController();
-		const options = {
-			signal: controller.signal
-		};
-		controller.abort();
-		const fetched = fetch(url, options);
-		return expect(fetched).to.eventually.be.rejected
-			.and.be.an.instanceOf(Error)
-			.and.include({
-				type: 'aborted',
-				name: 'AbortError'
+			beforeEach(() => {
+				controller = buildAbortController();
 			});
-	});
 
-	it('should remove internal AbortSignal event listener after request is aborted', () => {
-		const controller = new AbortController();
-		const {signal} = controller;
-		const promise = fetch(
-			`${base}timeout`,
-			{signal}
-		);
-		const result = expect(promise).to.eventually.be.rejected
-			.and.be.an.instanceof(Error)
-			.and.have.property('name', 'AbortError')
-			.then(() => {
-				expect(signal.listeners.abort.length).to.equal(0);
-			});
-		controller.abort();
-		return result;
-	});
+			it('should support request cancellation with signal', () => {
+				const fetches = [
+					fetch(
+						`${base}timeout`,
+						{
+							method: 'POST',
+							signal: controller.signal,
+							headers: {
+								'Content-Type': 'application/json',
+								body: JSON.stringify({hello: 'world'})
+							}
+						}
+					)
+				];
+				setTimeout(() => {
+					controller.abort();
+				}, 100);
 
-	it('should allow redirects to be aborted', () => {
-		const abortController = new AbortController();
-		const request = new Request(`${base}redirect/slow`, {
-			signal: abortController.signal
-		});
-		setTimeout(() => {
-			abortController.abort();
-		}, 20);
-		return expect(fetch(request)).to.be.eventually.rejected
-			.and.be.an.instanceOf(Error)
-			.and.have.property('name', 'AbortError');
-	});
-
-	it('should allow redirected response body to be aborted', () => {
-		const abortController = new AbortController();
-		const request = new Request(`${base}redirect/slow-stream`, {
-			signal: abortController.signal
-		});
-		return expect(fetch(request).then(res => {
-			expect(res.headers.get('content-type')).to.equal('text/plain');
-			const result = res.text();
-			abortController.abort();
-			return result;
-		})).to.be.eventually.rejected
-			.and.be.an.instanceOf(Error)
-			.and.have.property('name', 'AbortError');
-	});
-
-	it('should remove internal AbortSignal event listener after request and response complete without aborting', () => {
-		const controller = new AbortController();
-		const {signal} = controller;
-		const fetchHtml = fetch(`${base}html`, {signal})
-			.then(res => res.text());
-		const fetchResponseError = fetch(`${base}error/reset`, {signal});
-		const fetchRedirect = fetch(`${base}redirect/301`, {signal}).then(res => res.json());
-		return Promise.all([
-			expect(fetchHtml).to.eventually.be.fulfilled.and.equal('<html></html>'),
-			expect(fetchResponseError).to.be.eventually.rejected,
-			expect(fetchRedirect).to.eventually.be.fulfilled
-		]).then(() => {
-			expect(signal.listeners.abort.length).to.equal(0);
-		});
-	});
-
-	it('should reject response body with AbortError when aborted before stream has been read completely', () => {
-		const controller = new AbortController();
-		return expect(fetch(
-			`${base}slow`,
-			{signal: controller.signal}
-		))
-			.to.eventually.be.fulfilled
-			.then(res => {
-				const promise = res.text();
-				controller.abort();
-				return expect(promise)
+				return Promise.all(fetches.map(fetched => expect(fetched)
 					.to.eventually.be.rejected
-					.and.be.an.instanceof(Error)
+					.and.be.an.instanceOf(Error)
+					.and.include({
+						type: 'aborted',
+						name: 'AbortError'
+					})
+				));
+			});
+
+			it('should support multiple request cancellation with signal', () => {
+				const fetches = [
+					fetch(`${base}timeout`, {signal: controller.signal}),
+					fetch(
+						`${base}timeout`,
+						{
+							method: 'POST',
+							signal: controller.signal,
+							headers: {
+								'Content-Type': 'application/json',
+								body: JSON.stringify({hello: 'world'})
+							}
+						}
+					)
+				];
+				setTimeout(() => {
+					controller.abort();
+				}, 100);
+
+				return Promise.all(fetches.map(fetched => expect(fetched)
+					.to.eventually.be.rejected
+					.and.be.an.instanceOf(Error)
+					.and.include({
+						type: 'aborted',
+						name: 'AbortError'
+					})
+				));
+			});
+
+			it('should reject immediately if signal has already been aborted', () => {
+				const url = `${base}timeout`;
+				const options = {
+					signal: controller.signal
+				};
+				controller.abort();
+				const fetched = fetch(url, options);
+				return expect(fetched).to.eventually.be.rejected
+					.and.be.an.instanceOf(Error)
+					.and.include({
+						type: 'aborted',
+						name: 'AbortError'
+					});
+			});
+
+			it('should allow redirects to be aborted', () => {
+				const request = new Request(`${base}redirect/slow`, {
+					signal: controller.signal
+				});
+				setTimeout(() => {
+					controller.abort();
+				}, 20);
+				return expect(fetch(request)).to.be.eventually.rejected
+					.and.be.an.instanceOf(Error)
 					.and.have.property('name', 'AbortError');
 			});
-	});
 
-	it('should reject response body methods immediately with AbortError when aborted before stream is disturbed', () => {
-		const controller = new AbortController();
-		return expect(fetch(
-			`${base}slow`,
-			{signal: controller.signal}
-		))
-			.to.eventually.be.fulfilled
-			.then(res => {
-				controller.abort();
-				return expect(res.text())
-					.to.eventually.be.rejected
-					.and.be.an.instanceof(Error)
+			it('should allow redirected response body to be aborted', () => {
+				const request = new Request(`${base}redirect/slow-stream`, {
+					signal: controller.signal
+				});
+				return expect(fetch(request).then(res => {
+					expect(res.headers.get('content-type')).to.equal('text/plain');
+					const result = res.text();
+					controller.abort();
+					return result;
+				})).to.be.eventually.rejected
+					.and.be.an.instanceOf(Error)
 					.and.have.property('name', 'AbortError');
 			});
-	});
 
-	it('should emit error event to response body with an AbortError when aborted before underlying stream is closed', done => {
-		const controller = new AbortController();
-		expect(fetch(
-			`${base}slow`,
-			{signal: controller.signal}
-		))
-			.to.eventually.be.fulfilled
-			.then(res => {
-				res.body.once('error', err => {
-					expect(err)
-						.to.be.an.instanceof(Error)
-						.and.have.property('name', 'AbortError');
-					done();
-				});
-				controller.abort();
+			it('should reject response body with AbortError when aborted before stream has been read completely', () => {
+				return expect(fetch(
+					`${base}slow`,
+					{signal: controller.signal}
+				))
+					.to.eventually.be.fulfilled
+					.then(res => {
+						const promise = res.text();
+						controller.abort();
+						return expect(promise)
+							.to.eventually.be.rejected
+							.and.be.an.instanceof(Error)
+							.and.have.property('name', 'AbortError');
+					});
 			});
-	});
 
-	it('should cancel request body of type Stream with AbortError when aborted', () => {
-		const controller = new AbortController();
-		const body = new stream.Readable({objectMode: true});
-		body._read = () => { };
-		const promise = fetch(
-			`${base}slow`,
-			{signal: controller.signal, body, method: 'POST'}
-		);
+			it('should reject response body methods immediately with AbortError when aborted before stream is disturbed', () => {
+				return expect(fetch(
+					`${base}slow`,
+					{signal: controller.signal}
+				))
+					.to.eventually.be.fulfilled
+					.then(res => {
+						controller.abort();
+						return expect(res.text())
+							.to.eventually.be.rejected
+							.and.be.an.instanceof(Error)
+							.and.have.property('name', 'AbortError');
+					});
+			});
 
-		const result = Promise.all([
-			new Promise((resolve, reject) => {
-				body.on('error', error => {
-					try {
-						expect(error).to.be.an.instanceof(Error).and.have.property('name', 'AbortError');
-						resolve();
-					} catch (error_) {
-						reject(error_);
-					}
+			it('should emit error event to response body with an AbortError when aborted before underlying stream is closed', done => {
+				expect(fetch(
+					`${base}slow`,
+					{signal: controller.signal}
+				))
+					.to.eventually.be.fulfilled
+					.then(res => {
+						res.body.once('error', err => {
+							expect(err)
+								.to.be.an.instanceof(Error)
+								.and.have.property('name', 'AbortError');
+							done();
+						});
+						controller.abort();
+					});
+			});
+
+			it('should cancel request body of type Stream with AbortError when aborted', () => {
+				const body = new stream.Readable({objectMode: true});
+				body._read = () => { };
+				const promise = fetch(
+					`${base}slow`,
+					{signal: controller.signal, body, method: 'POST'}
+				);
+
+				const result = Promise.all([
+					new Promise((resolve, reject) => {
+						body.on('error', error => {
+							try {
+								expect(error).to.be.an.instanceof(Error).and.have.property('name', 'AbortError');
+								resolve();
+							} catch (error_) {
+								reject(error_);
+							}
+						});
+					}),
+					expect(promise).to.eventually.be.rejected
+						.and.be.an.instanceof(Error)
+						.and.have.property('name', 'AbortError')
+				]);
+
+				controller.abort();
+
+				return result;
+			});
+
+			if (moreTests) {
+				moreTests();
+			}
+		});
+	};
+
+	testAbortController('polyfill',
+		() => new AbortControllerPolyfill(),
+		() => {
+			it('should remove internal AbortSignal event listener after request is aborted', () => {
+				const controller = new AbortControllerPolyfill();
+				const {signal} = controller;
+
+				setTimeout(() => {
+					controller.abort();
+				}, 20);
+
+				return expect(fetch(`${base}timeout`, {signal}))
+					.to.eventually.be.rejected
+					.and.be.an.instanceof(Error)
+					.and.have.property('name', 'AbortError')
+					.then(() => {
+						return expect(signal.listeners.abort.length).to.equal(0);
+					});
+			});
+
+			it('should remove internal AbortSignal event listener after request and response complete without aborting', () => {
+				const controller = new AbortControllerPolyfill();
+				const {signal} = controller;
+				const fetchHtml = fetch(`${base}html`, {signal})
+					.then(res => res.text());
+				const fetchResponseError = fetch(`${base}error/reset`, {signal});
+				const fetchRedirect = fetch(`${base}redirect/301`, {signal}).then(res => res.json());
+				return Promise.all([
+					expect(fetchHtml).to.eventually.be.fulfilled.and.equal('<html></html>'),
+					expect(fetchResponseError).to.be.eventually.rejected,
+					expect(fetchRedirect).to.eventually.be.fulfilled
+				]).then(() => {
+					expect(signal.listeners.abort.length).to.equal(0);
 				});
-			}),
-			expect(promise).to.eventually.be.rejected
-				.and.be.an.instanceof(Error)
-				.and.have.property('name', 'AbortError')
-		]);
+			});
+		}
+	);
 
-		controller.abort();
-
-		return result;
-	});
+	testAbortController('mysticatea', () => new AbortControllerMysticatea());
 
 	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
 		return Promise.all([

--- a/test/main.js
+++ b/test/main.js
@@ -1081,6 +1081,10 @@ describe('node-fetch', () => {
 
 	testAbortController('mysticatea', () => new AbortControllerMysticatea());
 
+	if (process.version > 'v15') {
+		testAbortController('native', () => new AbortController());
+	}
+
 	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
 		return Promise.all([
 			expect(fetch(`${base}inspect`, {signal: {}}))


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: Test improvements

**What changes did you make? (provide an overview)**

1. Setup all AbortController tests to run for both abortcontroller-polyfill and abort-controller implementations to correctly catch and diagnose errors like what happened when abortcontroller-polyfill was bumped to 1.6 and 1.7.0 (see https://github.com/mo/abortcontroller-polyfill/issues/53).  
2. Bumped abortcontroller-polyfill dependency to 1.7.1 since 1.6 and 1.7.0 are breaking

**Which issue (if any) does this pull request address?**

none

**Is there anything you'd like reviewers to know?**
