### PR TITLE
Add back eslint-disable for `!=` on signal

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -82,6 +82,7 @@ export default class Request extends Body {
 			signal = init.signal;
 		}
 
+		// eslint-disable-next-line no-eq-null, eqeqeq
 		if (signal != null && !isAbortSignal(signal)) {
 			throw new TypeError('Expected signal to be an instanceof AbortSignal or EventTarget');
 		}


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

The linter is failing on master because an `eslint-disable` directive was removed to allow for checking that `signal` is `null` or `undefined` (see 1f4f85e1bb2bd5263fe9c614751f327746174ffa)

**Which issue (if any) does this pull request address?**

none

**Is there anything you'd like reviewers to know?**

no