### PR TITLE
Wrap blobs into a node stream

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -177,7 +177,7 @@ async function consumeBody(data) {
 
 	// Body is blob
 	if (isBlob(body)) {
-		body = body.stream();
+		body = Stream.Readable.from(body.stream());
 	}
 
 	// Body is buffer
@@ -371,7 +371,7 @@ export const writeToStream = (dest, {body}) => {
 		dest.end();
 	} else if (isBlob(body)) {
 		// Body is Blob
-		body.stream().pipe(dest);
+		Stream.Readable.from(body.stream()).pipe(dest);
 	} else if (Buffer.isBuffer(body)) {
 		// Body is buffer
 		dest.write(body);

--- a/src/body.js
+++ b/src/body.js
@@ -14,6 +14,7 @@ import {FetchError} from './errors/fetch-error.js';
 import {FetchBaseError} from './errors/base.js';
 import {formDataIterator, getBoundary, getFormDataLength} from './utils/form-data.js';
 import {isBlob, isURLSearchParameters, isFormData} from './utils/is.js';
+import {blobToNodeStream} from './utils/blob-to-stream.js';
 
 const INTERNALS = Symbol('Body internals');
 
@@ -177,7 +178,7 @@ async function consumeBody(data) {
 
 	// Body is blob
 	if (isBlob(body)) {
-		body = Stream.Readable.from(body.stream());
+		body = blobToNodeStream(body);
 	}
 
 	// Body is buffer
@@ -371,7 +372,7 @@ export const writeToStream = (dest, {body}) => {
 		dest.end();
 	} else if (isBlob(body)) {
 		// Body is Blob
-		Stream.Readable.from(body.stream()).pipe(dest);
+		blobToNodeStream(body).pipe(dest);
 	} else if (Buffer.isBuffer(body)) {
 		// Body is buffer
 		dest.write(body);

--- a/src/utils/blob-to-stream.js
+++ b/src/utils/blob-to-stream.js
@@ -1,5 +1,6 @@
 import {Readable} from 'stream';
 
+/* c8 ignore start */
 async function * read(blob) {
 	let position = 0;
 	while (position !== blob.size) {
@@ -10,6 +11,7 @@ async function * read(blob) {
 		yield new Uint8Array(buffer);
 	}
 }
+/* c8 ignore end */
 
 export function blobToNodeStream(blob) {
 	return Readable.from(blob.stream ? blob.stream() : read(blob), {

--- a/src/utils/blob-to-stream.js
+++ b/src/utils/blob-to-stream.js
@@ -1,0 +1,18 @@
+import {Readable} from 'stream';
+
+async function * read(blob) {
+	let position = 0;
+	while (position !== blob.size) {
+		const chunk = blob.slice(position, Math.min(blob.size, position + 524288));
+		// eslint-disable-next-line no-await-in-loop
+		const buffer = await chunk.arrayBuffer();
+		position += buffer.byteLength;
+		yield new Uint8Array(buffer);
+	}
+}
+
+export function blobToNodeStream(blob) {
+	return Readable.from(blob.stream ? blob.stream() : read(blob), {
+		objectMode: false
+	});
+}

--- a/src/utils/blob-to-stream.js
+++ b/src/utils/blob-to-stream.js
@@ -1,10 +1,13 @@
 import {Readable} from 'stream';
 
+// 64 KiB (same size chrome slice theirs blob into Uint8array's)
+const POOL_SIZE = 65536
+
 /* c8 ignore start */
 async function * read(blob) {
 	let position = 0;
 	while (position !== blob.size) {
-		const chunk = blob.slice(position, Math.min(blob.size, position + 524288));
+		const chunk = blob.slice(position, Math.min(blob.size, position + POOL_SIZE));
 		// eslint-disable-next-line no-await-in-loop
 		const buffer = await chunk.arrayBuffer();
 		position += buffer.byteLength;

--- a/src/utils/blob-to-stream.js
+++ b/src/utils/blob-to-stream.js
@@ -1,7 +1,7 @@
 import {Readable} from 'stream';
 
 // 64 KiB (same size chrome slice theirs blob into Uint8array's)
-const POOL_SIZE = 65536
+const POOL_SIZE = 65536;
 
 /* c8 ignore start */
 async function * read(blob) {

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -41,6 +41,7 @@ export const isBlob = object => {
 		// typeof object.stream === 'function' &&
 		typeof object.constructor === 'function' &&
 		(
+			/* c8 ignore next 2 */
 			/^(Blob|File)$/.test(object[NAME]) ||
 			/^(Blob|File)$/.test(object.constructor.name)
 		)

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -38,9 +38,12 @@ export const isBlob = object => {
 		typeof object === 'object' &&
 		typeof object.arrayBuffer === 'function' &&
 		typeof object.type === 'string' &&
-		typeof object.stream === 'function' &&
+		// typeof object.stream === 'function' &&
 		typeof object.constructor === 'function' &&
-		/^(Blob|File)$/.test(object[NAME])
+		(
+			/^(Blob|File)$/.test(object[NAME]) ||
+			/^(Blob|File)$/.test(object.constructor.name)
+		)
 	);
 };
 

--- a/test/response.js
+++ b/test/response.js
@@ -3,6 +3,7 @@ import * as stream from 'stream';
 import {TextEncoder} from 'util';
 import chai from 'chai';
 import Blob from 'fetch-blob';
+import buffer from 'buffer';
 import {Response} from '../src/index.js';
 import TestServer from './utils/server.js';
 
@@ -172,6 +173,15 @@ describe('Response', () => {
 			expect(result).to.equal('a=1');
 		});
 	});
+
+	if (buffer.Blob) {
+		it('should support Buffer.Blob as body', () => {
+			const res = new Response(new buffer.Blob(['a=1']));
+			return res.text().then(result => {
+				expect(result).to.equal('a=1');
+			});
+		});
+	}
 
 	it('should support Uint8Array as body', () => {
 		const encoder = new TextEncoder();


### PR DESCRIPTION
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Regarding what type of blob.stream it is (whether it's a node stream, whatwg stream or just a async iterator that yields uint8arrays)
always wrap the stream it returns in to a node stream.

**Which issue (if any) does this pull request address?**
closes #1091

**Is there anything you'd like reviewers to know?**

`buffer.Blob()` is soon becoming a thing...