### PR TITLE
Don't change relative location header on manual redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,23 @@ console.dir(result);
 
 Passed through to the `insecureHTTPParser` option on http(s).request. See [`http.request`](https://nodejs.org/api/http.html#http_http_request_url_options_callback) for more information.
 
+#### Manual Redirect
+
+The `redirect: 'manual'` option for node-fetch is different from the browser & specification, which
+results in an [opaque-redirect filtered response](https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect).
+node-fetch gives you the typical [basic filtered response](https://fetch.spec.whatwg.org/#concept-filtered-response-basic) instead.
+
+```js
+const fetch = require('node-fetch');
+
+const response = await fetch('https://httpbin.org/status/301', { redirect: 'manual' });
+
+if (response.status === 301 || response.status === 302) {
+	const locationURL = new URL(response.headers.get('location'), response.url);
+	const response2 = await fetch(locationURL, { redirect: 'manual' });
+	console.dir(response2);
+}
+```
 
 <a id="class-request"></a>
 

--- a/src/headers.js
+++ b/src/headers.js
@@ -7,6 +7,7 @@
 import {types} from 'node:util';
 import http from 'node:http';
 
+/* c8 ignore next 9 */
 const validateHeaderName = typeof http.validateHeaderName === 'function' ?
 	http.validateHeaderName :
 	name => {
@@ -17,6 +18,7 @@ const validateHeaderName = typeof http.validateHeaderName === 'function' ?
 		}
 	};
 
+/* c8 ignore next 9 */
 const validateHeaderValue = typeof http.validateHeaderValue === 'function' ?
 	http.validateHeaderValue :
 	(name, value) => {
@@ -141,8 +143,8 @@ export default class Headers extends URLSearchParams {
 						return Reflect.get(target, p, receiver);
 				}
 			}
-			/* c8 ignore next */
 		});
+		/* c8 ignore next */
 	}
 
 	get [Symbol.toStringTag]() {

--- a/src/index.js
+++ b/src/index.js
@@ -154,11 +154,7 @@ export default async function fetch(url, options_) {
 						finalize();
 						return;
 					case 'manual':
-						// Node-fetch-specific step: make manual redirect a bit easier to use by setting the Location header value to the resolved URL.
-						if (locationURL !== null) {
-							headers.set('Location', locationURL);
-						}
-
+						// Nothing to do
 						break;
 					case 'follow': {
 						// HTTP-redirect fetch step 2

--- a/src/index.js
+++ b/src/index.js
@@ -237,6 +237,7 @@ export default async function fetch(url, options_) {
 
 			let body = pump(response_, new PassThrough(), reject);
 			// see https://github.com/nodejs/node/pull/29376
+			/* c8 ignore next 3 */
 			if (process.version < 'v12.10') {
 				response_.on('aborted', abortAndFinalize);
 			}

--- a/test/main.js
+++ b/test/main.js
@@ -446,7 +446,10 @@ describe('node-fetch', () => {
 		return fetch(url, options).then(res => {
 			expect(res.url).to.equal(url);
 			expect(res.status).to.equal(301);
-			expect(res.headers.get('location')).to.equal(`${base}inspect`);
+			expect(res.headers.get('location')).to.equal('/inspect');
+
+			const locationURL = new URL(res.headers.get('location'), url);
+			expect(locationURL.href).to.equal(`${base}inspect`);
 		});
 	});
 
@@ -458,7 +461,22 @@ describe('node-fetch', () => {
 		return fetch(url, options).then(res => {
 			expect(res.url).to.equal(url);
 			expect(res.status).to.equal(301);
-			expect(res.headers.get('location')).to.equal(`${base}redirect/%C3%A2%C2%98%C2%83`);
+			expect(res.headers.get('location')).to.equal('<>');
+
+			const locationURL = new URL(res.headers.get('location'), url);
+			expect(locationURL.href).to.equal(`${base}redirect/%3C%3E`);
+		});
+	});
+
+	it('should support redirect mode to other host, manual flag', () => {
+		const url = `${base}redirect/301/otherhost`;
+		const options = {
+			redirect: 'manual'
+		};
+		return fetch(url, options).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.status).to.equal(301);
+			expect(res.headers.get('location')).to.equal('https://github.com/node-fetch');
 		});
 	});
 

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -251,6 +251,12 @@ export default class TestServer {
 			res.end();
 		}
 
+		if (p === '/redirect/301/otherhost') {
+			res.statusCode = 301;
+			res.setHeader('Location', 'https://github.com/node-fetch');
+			res.end();
+		}
+
 		if (p === '/redirect/302') {
 			res.statusCode = 302;
 			res.setHeader('Location', '/inspect');
@@ -309,7 +315,7 @@ export default class TestServer {
 		}
 
 		if (p === '/redirect/bad-location') {
-			res.socket.write('HTTP/1.1 301\r\nLocation: ☃\r\nContent-Length: 0\r\n');
+			res.socket.write('HTTP/1.1 301\r\nLocation: <>\r\nContent-Length: 0\r\n');
 			res.socket.end('\r\n');
 		}
 


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

This removes the code that changes the location header to an absolute URL in the case of a manual redirect request. While doing this is helpful in most cases, it is too destructive in cases where the original, actual location header is needed.  See the situation described in #1086.

This change also [documents the variation from the spec](https://github.com/node-fetch/node-fetch/commit/8232b423f2d9df549e7a23cd6b6ebff23c8d744b#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

This change reduces the total lines of code, thus reducing the overall test percentage for test coverage.  To keep that check passing, I added some appropriate c8 ignores to unrelated code (see https://github.com/node-fetch/node-fetch/pull/1105/commits/52f864bf57b3a7ada44e0f5a9aebd6f8641f2cbc)

**Which issue (if any) does this pull request address?**

Fixes #1086 

**Is there anything you'd like reviewers to know?**

No