### PR TITLE
Fix `this` arg for URLSearchParams prototype call

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -114,7 +114,7 @@ export default class Headers extends URLSearchParams {
 							validateHeaderName(name);
 							validateHeaderValue(name, String(value));
 							return URLSearchParams.prototype[p].call(
-								receiver,
+								target,
 								String(name).toLowerCase(),
 								String(value)
 							);
@@ -126,7 +126,7 @@ export default class Headers extends URLSearchParams {
 						return name => {
 							validateHeaderName(name);
 							return URLSearchParams.prototype[p].call(
-								receiver,
+								target,
 								String(name).toLowerCase()
 							);
 						};


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

Changed the `this` arg passed to the URLSearchParams prototype call in the Headers proxy handlers for `append()`, `set()`, `delete()`, `has()`, `getAll()`. Currently it's set to `receiver`, but it should be `target`, as it is [with the `keys()` handler](https://github.com/node-fetch/node-fetch/blob/d8fc32d6b29bd43d1ad377e80b3e439fe37f2904/src/headers.js#L137).

**Which issue (if any) does this pull request address?**

#917 

**Is there anything you'd like reviewers to know?**

Ran the tests in Node (v14.15.0) and everything continues to pass. Manually tested in Electron (v11.1.1, with Node v12.18.3 and Chrome v87.0.4280.88), and it fixes the issue described in #917. 