### PR TITLE
Fix/form data in response

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -197,14 +197,15 @@ async function consumeBody(data) {
 
 	try {
 		for await (const chunk of body) {
-			if (data.size > 0 && accumBytes + chunk.length > data.size) {
+			const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk
+			if (data.size > 0 && accumBytes + bytes.byteLength > data.size) {
 				const err = new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size');
 				body.destroy(err);
 				throw err;
 			}
 
-			accumBytes += chunk.length;
-			accum.push(chunk);
+			accumBytes += bytes.byteLength;
+			accum.push(bytes);
 		}
 	} catch (error) {
 		if (error instanceof FetchBaseError) {
@@ -217,10 +218,6 @@ async function consumeBody(data) {
 
 	if (body.readableEnded === true || body._readableState.ended === true) {
 		try {
-			if (accum.every(c => typeof c === 'string')) {
-				return Buffer.from(accum.join(''));
-			}
-
 			return Buffer.concat(accum, accumBytes);
 		} catch (error) {
 			throw new FetchError(`Could not create Buffer from response body for ${data.url}: ${error.message}`, 'system', error);

--- a/src/body.js
+++ b/src/body.js
@@ -61,6 +61,7 @@ export default class Body {
 		}
 
 		this[INTERNALS] = {
+			/** @type {Stream|Buffer|Blob|null} */
 			body,
 			boundary,
 			disturbed: false,
@@ -320,7 +321,7 @@ export const extractContentType = (body, request) => {
  *
  * ref: https://fetch.spec.whatwg.org/#concept-body-total-bytes
  *
- * @param {any} obj.body Body object from the Body instance.
+ * @param {Body} request Body object from the Body instance.
  * @returns {number | null}
  */
 export const getTotalBytes = request => {

--- a/src/body.js
+++ b/src/body.js
@@ -197,7 +197,7 @@ async function consumeBody(data) {
 
 	try {
 		for await (const chunk of body) {
-			const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk
+			const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
 			if (data.size > 0 && accumBytes + bytes.byteLength > data.size) {
 				const err = new FetchError(`content size at ${data.url} over limit: ${data.size}`, 'max-size');
 				body.destroy(err);

--- a/src/response.js
+++ b/src/response.js
@@ -25,7 +25,7 @@ export default class Response extends Body {
 		const headers = new Headers(options.headers);
 
 		if (body !== null && !headers.has('Content-Type')) {
-			const contentType = extractContentType(body);
+			const contentType = extractContentType(body, this);
 			if (contentType) {
 				headers.append('Content-Type', contentType);
 			}

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -11,7 +11,7 @@ const NAME = Symbol.toStringTag;
  * ref: https://github.com/node-fetch/node-fetch/issues/296#issuecomment-307598143
  *
  * @param  {*} obj
- * @return {boolean}
+ * @return {object is URLSearchParams}
  */
 export const isURLSearchParameters = object => {
 	return (
@@ -31,7 +31,7 @@ export const isURLSearchParameters = object => {
  * Check if `object` is a W3C `Blob` object (which `File` inherits from)
  *
  * @param  {*} obj
- * @return {boolean}
+ * @return {object is Blob}
  */
 export const isBlob = object => {
 	return (
@@ -48,7 +48,7 @@ export const isBlob = object => {
  * Check if `obj` is a spec-compliant `FormData` object
  *
  * @param {*} object
- * @return {boolean}
+ * @return {object is FormData}
  */
 export function isFormData(object) {
 	return (
@@ -70,7 +70,7 @@ export function isFormData(object) {
  * Check if `obj` is an instance of AbortSignal.
  *
  * @param  {*} obj
- * @return {boolean}
+ * @return {object is AbortSignal}
  */
 export const isAbortSignal = object => {
 	return (

--- a/test/form-data.js
+++ b/test/form-data.js
@@ -103,7 +103,7 @@ describe('FormData', () => {
 		expect(String(await read(formDataIterator(form, boundary)))).to.be.equal(expected);
 	});
 
-	it.only('Response derives content-type from FormData', async () => {
+	it('Response derives content-type from FormData', async () => {
 		const form = new FormData();
 		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
 

--- a/test/form-data.js
+++ b/test/form-data.js
@@ -1,5 +1,6 @@
 import FormData from 'formdata-node';
 import Blob from 'fetch-blob';
+import { Response } from '../src/index.js';
 
 import chai from 'chai';
 
@@ -100,5 +101,15 @@ describe('FormData', () => {
 		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
 
 		expect(String(await read(formDataIterator(form, boundary)))).to.be.equal(expected);
+	});
+
+	it.only('Response derives content-type from FormData', async () => {
+		const form = new FormData();
+		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
+
+		const response = new Response(form)
+		const type = response.headers.get('content-type') || ''
+		expect(type).to.match(/multipart\/form-data;\s*boundary=/)
+		expect(await response.text()).to.have.string('Hello, World!')
 	});
 });

--- a/test/form-data.js
+++ b/test/form-data.js
@@ -1,6 +1,6 @@
 import FormData from 'formdata-node';
 import Blob from 'fetch-blob';
-import { Response } from '../src/index.js';
+import {Response} from '../src/index.js';
 
 import chai from 'chai';
 
@@ -107,9 +107,9 @@ describe('FormData', () => {
 		const form = new FormData();
 		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
 
-		const response = new Response(form)
-		const type = response.headers.get('content-type') || ''
-		expect(type).to.match(/multipart\/form-data;\s*boundary=/)
-		expect(await response.text()).to.have.string('Hello, World!')
+		const response = new Response(form);
+		const type = response.headers.get('content-type') || '';
+		expect(type).to.match(/multipart\/form-data;\s*boundary=/);
+		expect(await response.text()).to.have.string('Hello, World!');
 	});
 });

--- a/test/form-data.js
+++ b/test/form-data.js
@@ -1,6 +1,7 @@
 import FormData from 'formdata-node';
 import Blob from 'fetch-blob';
-import {Response} from '../src/index.js';
+import {Response, Request} from '../src/index.js';
+import {getTotalBytes} from '../src/body.js';
 
 import chai from 'chai';
 
@@ -103,7 +104,7 @@ describe('FormData', () => {
 		expect(String(await read(formDataIterator(form, boundary)))).to.be.equal(expected);
 	});
 
-	it('Response derives content-type from FormData', async () => {
+	it('Response supports FormData body', async () => {
 		const form = new FormData();
 		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
 
@@ -111,5 +112,21 @@ describe('FormData', () => {
 		const type = response.headers.get('content-type') || '';
 		expect(type).to.match(/multipart\/form-data;\s*boundary=/);
 		expect(await response.text()).to.have.string('Hello, World!');
+		// Note: getTotalBytes assumes body could be form data but it never is
+		// because it gets normalized into a stream.
+		expect(getTotalBytes({...response, body: form})).to.be.greaterThan(20);
+	});
+
+	it('Request supports FormData body', async () => {
+		const form = new FormData();
+		form.set('blob', new Blob(['Hello, World!'], {type: 'text/plain'}));
+
+		const request = new Request('https://github.com/node-fetch/', {
+			body: form,
+			method: 'POST'
+		});
+		const type = request.headers.get('content-type') || '';
+		expect(type).to.match(/multipart\/form-data;\s*boundary=/);
+		expect(await request.text()).to.have.string('Hello, World!');
 	});
 });


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

1. Added a test case illustrating an issue
2. Addressed a bug caused by missed function argument in `Response` implementation.
3. Addressed issue with form-data body where boundary fragments are emitted as strings while content fragments as binary data. Which caused exceptions.

**Which issue (if any) does this pull request address?**

See test case illustrating the issue. It throws exception without this fix.

**Is there anything you'd like reviewers to know?**

1. I had to workaround code coverage problem which reported issue for the line https://coveralls.io/builds/38068042/source?filename=src%2Fbody.js#L350 which is unreachable because `FormData` body is normalized into a stream and I don't believe there are no code paths in which request/response `.body` could be `FormData`.
   
    https://github.com/node-fetch/node-fetch/blob/1780f5ae89107ded4f232f43219ab0e548b0647c/src/body.js#L53-L56

    I do not believe changes here affected code coverage, however instead of removing those lines (which break no tests) I've added a assertion to exercise that code path.

2. Normalizing `FormData` to stream during body initialization has a problem of making content length undetectable: 
    https://github.com/node-fetch/node-fetch/blob/1780f5ae89107ded4f232f43219ab0e548b0647c/src/request.js#L172

    And this code path will never be called

    https://github.com/node-fetch/node-fetch/blob/1780f5ae89107ded4f232f43219ab0e548b0647c/src/body.js#L352-L355

    But I'll defer this to another issue

3. (Last) commit dc5be05 adds bunch of type annotations which helped me to reason through by getting better IntelliSense as opposed to remembering all the ins and outs. Feel free to get rid of it if you don't want them.
