### PR TITLE
Update README.md to fix HTTPResponseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ const fetch = require('node-fetch');
 
 class HTTPResponseError extends Error {
 	constructor(response, ...args) {
-		this.response = response;
 		super(`HTTP Error Response: ${response.status} ${response.statusText}`, ...args);
+		this.response = response;
 	}
 }
 


### PR DESCRIPTION
In the 'Handling client and server errors', the class HTTPResponseError constructor has to call 'super()' before accessing 'this.response'

Not doing this throws the following exception: "ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor"

Fix: This just changes the order so super(...) is first, then this.response...

MDN Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super#using_super_in_classes

<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
