### PR TITLE
Update response.js

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -93,7 +93,8 @@ export default class Response extends Body {
 			headers: this.headers,
 			ok: this.ok,
 			redirected: this.redirected,
-			size: this.size
+			size: this.size,
+			highWaterMark: this.highWaterMark
 		});
 	}
 

--- a/test/response.js
+++ b/test/response.js
@@ -123,7 +123,8 @@ describe('Response', () => {
 			},
 			url: base,
 			status: 346,
-			statusText: 'production'
+			statusText: 'production',
+			highWaterMark: 789
 		});
 		const cl = res.clone();
 		expect(cl.headers.get('a')).to.equal('1');
@@ -131,6 +132,7 @@ describe('Response', () => {
 		expect(cl.url).to.equal(base);
 		expect(cl.status).to.equal(346);
 		expect(cl.statusText).to.equal('production');
+		expect(cl.highWaterMark).to.equal(789)
 		expect(cl.ok).to.be.false;
 		// Clone body shouldn't be the same body
 		expect(cl.body).to.not.equal(body);


### PR DESCRIPTION
Allow `Response.clone()` to persist the high water mark

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Added `highWaterMark` to the `Request.clone()` method, along with the other properties.

**Which issue (if any) does this pull request address?**
https://github.com/node-fetch/node-fetch/issues/1161
