### PR TITLE
Add typing for Response.redirect(url, status)

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -157,6 +157,7 @@ export class Response extends BodyMixin {
 	clone(): Response;
 
 	static error(): Response;
+	static redirect(url: string, status?: number): Response;
 }
 
 export class FetchError extends Error {

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -88,6 +88,9 @@ async function run() {
 		new Map([['a', null], ['3', null]]).keys()
 	]);
 	/* eslint-enable no-new */
+
+	expectType<Response>(Response.redirect('https://google.com'));
+	expectType<Response>(Response.redirect('https://google.com', 301));
 }
 
 run().finally(() => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update

**What changes did you make?**

In https://github.com/node-fetch/node-fetch/pull/1078, the static `Response.redirect(url, status)` was added to the project but without typings which can be confusing for users. This pull request provides the typings for the method.
