### PR TITLE
fix: premature close with chunked transfer encoding and for async iterators in Node 12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,8 @@
         } ]
       ],
       plugins: [
-        './build/babel-plugin'
+        './build/babel-plugin',
+        'transform-async-generator-functions'
       ]
     },
     coverage: {
@@ -31,7 +32,8 @@
       ],
       plugins: [
         [ 'istanbul', { exclude: [ 'src/blob.js', 'build', 'test' ] } ],
-        './build/babel-plugin'
+        './build/babel-plugin',
+        'transform-async-generator-functions'
       ]
     },
     rollup: {

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
+  - "14"
   - "node"
 env:
   - FORMDATA_VERSION=1.0.0

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
         "abortcontroller-polyfill": "^1.3.0",
         "babel-core": "^6.26.3",
         "babel-plugin-istanbul": "^4.1.6",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-polyfill": "^6.26.0",
         "babel-preset-env": "^1.6.1",
         "babel-register": "^6.16.3",
         "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-iterator": "^1.1.1",
         "chai-string": "~1.3.0",
-        "codecov": "^3.3.0",
+        "codecov": "3.3.0",
         "cross-env": "^5.2.0",
         "form-data": "^2.3.3",
         "is-builtin-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "babel-plugin-istanbul": "^4.1.6",
         "babel-plugin-transform-async-generator-functions": "^6.24.1",
         "babel-polyfill": "^6.26.0",
-        "babel-preset-env": "^1.6.1",
+        "babel-preset-env": "1.4.0",
         "babel-register": "^6.16.3",
         "chai": "^3.5.0",
         "chai-as-promised": "^7.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,6 @@ export default {
       return true;
     }
     id = id.split('/').slice(0, id[0] === '@' ? 2 : 1).join('/');
-    return !!require('./package.json').dependencies[id];
+    return !!(require('./package.json').dependencies || {})[id];
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 	request.on('response', response => {
 		const {headers} = response;
 		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
-			socket.addListener('close', hadError => {
+			response.once('close', hadError => {
 				// if a data listener is still present we didn't end cleanly
 				const hasDataListener = socket.listenerCount('data') > 0;
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export default function fetch(url, opts) {
 			// Before Node.js 14, pipeline() does not fully support async iterators and does not always
 			// properly handle when the socket close/end events are out of order.
 			req.on('socket', s => {
-				s.prependListener('close', hadError => {
+				s.addListener('close', hadError => {
 					// if a data listener is still present we didn't end cleanly
 					const hasDataListener = s.listenerCount('data') > 0
 
@@ -311,7 +311,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 				properLastChunkReceived = Buffer.compare(buf.slice(-3), LAST_CHUNK) === 0;
 			});
 
-			socket.prependListener('close', () => {
+			socket.addListener('close', () => {
 				if (!properLastChunkReceived) {
 					const err = new Error('Premature close');
 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,10 @@ export default function fetch(url, opts) {
 		});
 
 		fixResponseChunkedTransferBadEnding(req, err => {
+			if (signal && signal.aborted) {
+				return
+			}
+
 			if (response.body.destroy) {
 				response.body.destroy(err);
 			} else {
@@ -118,7 +122,7 @@ export default function fetch(url, opts) {
 					const hasDataListener = s.listenerCount('data') > 0
 
 					// if end happened before close but the socket didn't emit an error, do it now
-					if (response && hasDataListener && !hadError) {
+					if (response && hasDataListener && !hadError && !(signal && signal.aborted)) {
 						const err = new Error('Premature close');
 						err.code = 'ERR_STREAM_PREMATURE_CLOSE';
 						response.body.emit('error', err);

--- a/test/server.js
+++ b/test/server.js
@@ -323,13 +323,24 @@ export default class TestServer {
 				'Transfer-Encoding': 'chunked'
 			});
 
-			res.write(`${JSON.stringify({data: 'hi'})}\n`);
+			// Transfer-Encoding: 'chunked' sends chunk sizes followed by the
+			// chunks - https://en.wikipedia.org/wiki/Chunked_transfer_encoding
+			const sendChunk = (obj) => {
+				const data = JSON.stringify(obj)
+
+				res.write(`${data.length}\r\n`)
+				res.write(`${data}\r\n`)
+			}
+
+			sendChunk({data: 'hi'})
 
 			setTimeout(() => {
-				res.write(`${JSON.stringify({data: 'bye'})}\n`);
+				sendChunk({data: 'bye'})
 			}, 200);
 
 			setTimeout(() => {
+				// should send '0\r\n\r\n' to end the response properly but instead
+				// just close the connection
 				res.destroy();
 			}, 400);
 		}

--- a/test/server.js
+++ b/test/server.js
@@ -317,6 +317,23 @@ export default class TestServer {
 			res.destroy();
 		}
 
+		if (p === '/error/premature/chunked') {
+			res.writeHead(200, {
+				'Content-Type': 'application/json',
+				'Transfer-Encoding': 'chunked'
+			});
+
+			res.write(`${JSON.stringify({data: 'hi'})}\n`);
+
+			setTimeout(() => {
+				res.write(`${JSON.stringify({data: 'bye'})}\n`);
+			}, 200);
+
+			setTimeout(() => {
+				res.destroy();
+			}, 400);
+		}
+
 		if (p === '/error/json') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');

--- a/test/test.js
+++ b/test/test.js
@@ -1089,7 +1089,7 @@ describe('node-fetch', () => {
 		))
 			.to.eventually.be.fulfilled
 			.then((res) => {
-				res.body.once('error', (err) => {
+				res.body.on('error', (err) => {
 					expect(err)
 						.to.be.an.instanceof(Error)
 						.and.have.property('name', 'AbortError');

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,7 @@
 
+import 'babel-core/register'
+import 'babel-polyfill'
+
 // test tools
 import chai from 'chai';
 import chaiPromised from 'chai-as-promised';
@@ -552,6 +555,74 @@ describe('node-fetch', () => {
 			.and.have.property('code', 'ECONNRESET');
 	});
 
+	it('should handle network-error in chunked response', () => {
+		const url = `${base}error/premature/chunked`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+
+			return expect(new Promise((resolve, reject) => {
+				res.body.on('error', reject);
+				res.body.on('close', resolve);
+			})).to.eventually.be.rejectedWith(Error, 'Premature close')
+				.and.have.property('code', 'ERR_STREAM_PREMATURE_CLOSE');
+		});
+	});
+
+	it('should handle network-error in chunked response async iterator', () => {
+		const url = `${base}error/premature/chunked`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+
+			const read = async body => {
+				const chunks = [];
+
+				if (process.version < 'v14') {
+					// In Node.js 12, some errors don't come out in the async iterator; we have to pick
+					// them up from the event-emitter and then throw them after the async iterator
+					let error;
+					body.on('error', err => {
+						error = err;
+					});
+
+					for await (const chunk of body) {
+						chunks.push(chunk);
+					}
+
+					if (error) {
+						throw error;
+					}
+
+					return new Promise(resolve => {
+						body.on('close', () => resolve(chunks));
+					});
+				}
+
+				for await (const chunk of body) {
+					chunks.push(chunk);
+				}
+
+				return chunks;
+			};
+
+			return expect(read(res.body))
+				.to.eventually.be.rejectedWith(Error, 'Premature close')
+				.and.have.property('code', 'ERR_STREAM_PREMATURE_CLOSE');
+		});
+	});
+
+	it('should handle network-error in chunked response in consumeBody', () => {
+		const url = `${base}error/premature/chunked`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+
+			return expect(res.text())
+				.to.eventually.be.rejectedWith(Error, 'Premature close');
+		});
+	});
+
 	it('should handle DNS-error response', function() {
 		const url = 'http://domain.invalid';
 		return expect(fetch(url)).to.eventually.be.rejected
@@ -1015,7 +1086,7 @@ describe('node-fetch', () => {
 		))
 			.to.eventually.be.fulfilled
 			.then((res) => {
-				res.body.on('error', (err) => {
+				res.body.once('error', (err) => {
 					expect(err)
 						.to.be.an.instanceof(Error)
 						.and.have.property('name', 'AbortError');

--- a/test/test.js
+++ b/test/test.js
@@ -569,7 +569,10 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should handle network-error in chunked response async iterator', () => {
+	// Skip test if streams are not async iterators (node < 10)
+	const itAsyncIterator = Boolean(new stream.PassThrough()[Symbol.asyncIterator]) ? it : it.skip;
+
+	itAsyncIterator('should handle network-error in chunked response async iterator', () => {
 		const url = `${base}error/premature/chunked`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);


### PR DESCRIPTION
This PR backports the fix from #1064 to the `2.x.x` branch following the [comment here](https://github.com/node-fetch/node-fetch/pull/1064#issuecomment-849167400).

I had to add some extra babel config to allow using the `for await..of` syntax in the tests.  The config is only needed for the tests as this syntax is not used in the implementation.