### PR TITLE
Specify possible HTTP request methods in types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -53,6 +53,8 @@ declare class Headers {
 	raw(): Record<string, string[]>;
 }
 
+type Methods = "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "OPTIONS" | "PATCH"
+
 interface RequestInit {
 	/**
 	 * A BodyInit object or null to set request's body.
@@ -65,7 +67,7 @@ interface RequestInit {
 	/**
 	 * A string to set request's method.
 	 */
-	method?: string;
+	method?: Methods;
 	/**
 	 * A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect.
 	 */
@@ -127,7 +129,7 @@ declare class Request extends Body {
 	/**
 	 * Returns request's HTTP method, which is "GET" by default.
 	 */
-	readonly method: string;
+	readonly method: Methods;
 	/**
 	 * Returns the redirect mode associated with request, which is a string indicating how redirects for the request will be handled during fetching. A request will follow redirects by default.
 	 */


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [X] Documentation update (improving types)
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Added a "Methods" type to index.d.ts that covers all the HTTP request methods supported by node-fetch

**Which issue (if any) does this pull request address?**
There didn't seem to be any open issues regarding this

**Is there anything you'd like reviewers to know?**
I know that the method parameter is case insensitive but it's common practice to write HTTP methods in upper case, which is why I only added those, let me know if you want me to change that though.
