### PR TITLE
Bump fetch-blob dependency to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^3.0.1",
-    "fetch-blob": "^2.1.1"
+    "fetch-blob": "^3.0.1"
   },
   "esm": {
     "sourceMap": true,


### PR DESCRIPTION
This fixes the "engines" restriction to Node.js 10.x only.