### PR TITLE
fix(Body): Discurage form-data and buffer()

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -297,6 +297,11 @@ export const extractContentType = (body, request) => {
 		return null;
 	}
 
+
+	if (isFormData(body)) {
+		return `multipart/form-data; boundary=${request[INTERNALS].boundary}`;
+	}
+
 	// Detect form data input from form-data module
 	if (body && typeof body.getBoundary === 'function') {
 		if (!warnedUsingOldFormData) {
@@ -309,10 +314,6 @@ export const extractContentType = (body, request) => {
 			warnedUsingOldFormData = true;
 		}
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
-	}
-
-	if (isFormData(body)) {
-		return `multipart/form-data; boundary=${request[INTERNALS].boundary}`;
 	}
 
 	// Body is stream - can't really do much about this

--- a/src/body.js
+++ b/src/body.js
@@ -297,7 +297,6 @@ export const extractContentType = (body, request) => {
 		return null;
 	}
 
-
 	if (isFormData(body)) {
 		return `multipart/form-data; boundary=${request[INTERNALS].boundary}`;
 	}
@@ -305,14 +304,15 @@ export const extractContentType = (body, request) => {
 	// Detect form data input from form-data module
 	if (body && typeof body.getBoundary === 'function') {
 		if (!warnedUsingOldFormData) {
-			console.warn('\x1b[33m%s\x1b[0m', `[WARN]`, `
+			console.warn('\u001B[33m%s\u001B[0m', '[WARN]', `
 	You are probably using form-data.
 	form-data doesn't follow the spec and requires special treatment.
 	We will eventually remove support for form-data.
 	See alternatives https://github.com/node-fetch/node-fetch/issues/1167
-			`)
+			`);
 			warnedUsingOldFormData = true;
 		}
+
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
 	}
 

--- a/src/body.js
+++ b/src/body.js
@@ -259,6 +259,8 @@ export const clone = (instance, highWaterMark) => {
 	return body;
 };
 
+let warnedUsingOldFormData = false;
+
 /**
  * Performs the operation "extract a `Content-Type` value from |object|" as
  * specified in the specification:
@@ -297,6 +299,15 @@ export const extractContentType = (body, request) => {
 
 	// Detect form data input from form-data module
 	if (body && typeof body.getBoundary === 'function') {
+		if (!warnedUsingOldFormData) {
+			console.warn('\x1b[33m%s\x1b[0m', `[WARN]`, `
+	You are probably using form-data.
+	form-data doesn't follow the spec and requires special treatment.
+	We will eventually remove support for form-data.
+	See alternatives https://github.com/node-fetch/node-fetch/issues/1167
+			`)
+			warnedUsingOldFormData = true;
+		}
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
 	}
 
@@ -345,7 +356,7 @@ export const getTotalBytes = request => {
 		return body.hasKnownLength && body.hasKnownLength() ? body.getLengthSync() : null;
 	}
 
-	// Body is a spec-compliant form-data
+	// Body is a spec-compliant FormData
 	if (isFormData(body)) {
 		return getFormDataLength(request[INTERNALS].boundary);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
- We do serialize spec compatible FormData ourself now. 
- We like to reduce the complexity of the core by removing support for form-data. 
- form-data have had a long time to become spec compliant but haven't done that
- using `res.buffer` is no good as it's a nodejs only feature, if ppl depend on this it only makes it more node-specific
we now strive to more spec compatible ways and more cross platform solutions. 

## Changes
This will output a one time warning when using form-data
![image](https://user-images.githubusercontent.com/1148376/126084161-994a97cc-5d84-453b-b9af-867e9b2bc929.png)

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] Readme recommends 2 other spec compatible alternatives already
- [x] The onetime warning references the issue at hand to resolve this.

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #1167 