### PR TITLE
template: Make PR template more task oriented 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 -------------------------------------------------------------------------------------------------
 
-<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit -->
+<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
 - [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
 - [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
 - [ ] I updated ./docs/v3-UPGRADE-GUIDE

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thanks for contributing! -->
 
-## The purpose of this pull is:
+## The purpose of this PR is:
 ...
 
 ## This is what had to change:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 ...
 
 
-
+-------------------------------------------------------------------------------------------------
 
 <!-- TASKMASTER: Mark what you have done, Remove unnecessary ones. Add new tasks that may fit -->
 - [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 <!-- Thanks for contributing! -->
 
-## The purpose of this PR is:
+## Purpose
 ...
 
-## This is what had to change:
+## Changes
 ...
 
-## This is what like reviewers to know:
+## Additional information
 ...
 
 
@@ -17,9 +17,9 @@
 - [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
 - [ ] I updated ./docs/v3-UPGRADE-GUIDE
 - [ ] I updated the README.md
-- [ ] I Added unit test(s)
+- [ ] I added unit test(s)
 
 -------------------------------------------------------------------------------------------------
 
-<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
+<!-- Add a `- fix #_NUMBER_` line for every PR/Issue this PR solves. Don't comma separate them -->
 - fix #000

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 ...
 
 
--------------------------------------------------------------------------------------------------
+___
 
 <!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
 - [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
@@ -19,7 +19,7 @@
 - [ ] I updated the README.md
 - [ ] I added unit test(s)
 
--------------------------------------------------------------------------------------------------
+___
 
-<!-- Add a `- fix #_NUMBER_` line for every PR/Issue this PR solves. Don't comma separate them -->
+<!-- Add a `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them -->
 - fix #000

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,23 @@
 <!-- Thanks for contributing! -->
 
 ## Purpose
-...
+
 
 ## Changes
-...
+
 
 ## Additional information
-...
 
 
 ___
 
-<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
+<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
 - [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
 - [ ] I updated ./docs/v3-UPGRADE-GUIDE
-- [ ] I updated the README.md
+- [ ] I updated readme
 - [ ] I added unit test(s)
 
 ___
 
-<!-- Add a `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them -->
-- fix #000
+<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
+- Fixes #000

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,23 @@
-<!--
-Please read and follow these instructions before creating and submitting a pull request:
+<!-- Thanks for contributing! -->
 
-- If you're fixing a bug, ensure you add unit tests to prove that it works.
-- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
-- If you are reporting a bug, adding failing units tests can be a good idea.
--->
+## The purpose of this pull is:
+...
 
-**What is the purpose of this pull request?**
+## This is what had to change:
+...
 
-- [ ] Documentation update
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Other, please explain:
+## This is what like reviewers to know:
+...
 
-**What changes did you make? (provide an overview)**
 
-**Which issue (if any) does this pull request address?**
 
-**Is there anything you'd like reviewers to know?**
+
+<!-- TASKMASTER: Mark what you have done, Remove unnecessary ones. Add new tasks that may fit -->
+- [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
+- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
+- [ ] I updated ./docs/v3-UPGRADE-GUIDE
+- [ ] I updated the README.md
+- [ ] I Added unit test(s)
+
+<!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
+- fix #0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,14 @@
 
 -------------------------------------------------------------------------------------------------
 
-<!-- TASKMASTER: Mark what you have done, Remove unnecessary ones. Add new tasks that may fit -->
+<!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit -->
 - [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
 - [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
 - [ ] I updated ./docs/v3-UPGRADE-GUIDE
 - [ ] I updated the README.md
 - [ ] I Added unit test(s)
 
+-------------------------------------------------------------------------------------------------
+
 <!-- Add a `- fix #_NUMBER_` line for every Issue this PR solves. Do not comma separate them -->
-- fix #0
+- fix #000

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@
 ___
 
 <!-- Mark what you have done, Remove unnecessary ones. Add new tasks that may fit (like TODO's) -->
-- [ ] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `
 - [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
 - [ ] I updated ./docs/v3-UPGRADE-GUIDE
 - [ ] I updated the README.md


### PR DESCRIPTION
## Purpose
- To create a more task oriented list to help ppl remember to update the docs/changelog
- Creating more meaning full standardized title  

## Changes
The tasks that shows up in the list of PR shows tasks.
It's often 1-2 out of 4 all the time. or 50% completed
![image](https://user-images.githubusercontent.com/1148376/127184835-b22adf08-0212-4cfa-b886-a4d48ee919e5.png)

I think we do not use them the "correct way" so I changed it. 
I also think this made the template less bloated, ppl don't like to read or follow the template so often 
( Less to read/follow === more they will write a better PR and actually follow the template/structure )

## Additional information
This PR uses this new template and this is what it looks like. (kind of... some parts are hidden/removed)


-------------------------------------------------------------------------------------------------

- [x] I prefixed the PR-title with `docs: `, `fix(area): `, `feat(area): ` or `breaking(area): `

-------------------------------------------------------------------------------------------------

- fix https://github.com/node-fetch/node-fetch/pull/825#issuecomment-643457324