### PR TITLE
chore(cjs/ems): Bundle module and use package exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
       - run: npm install
 
       - run: npm test -- --colors
+
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ node_modules
 # Babel-compiled files
 lib
 
+# esbuild-compiled files
+dist
+
 # Ignore package manager lock files
 package-lock.json
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -2,22 +2,32 @@
   "name": "node-fetch",
   "version": "3.0.0-beta.10",
   "description": "A light-weight module that brings Fetch API to node.js",
-  "main": "./src/index.js",
+  "main": "./dist/index.mjs",
   "sideEffects": false,
   "type": "module",
   "files": [
-    "src",
+    "dist",
     "@types/index.d.ts"
   ],
   "types": "./@types/index.d.ts",
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
   "scripts": {
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "esbuild src/index.js --bundle --platform=node --format=esm --outfile=dist/index.mjs",
+    "build:cjs": "esbuild src/index.js --bundle --platform=node --format=cjs --outfile=dist/index.cjs",
     "test": "mocha",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "test-types": "tsd",
-    "lint": "xo"
+    "lint": "xo",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -53,17 +63,16 @@
     "chai-iterator": "^3.0.2",
     "chai-string": "^1.5.0",
     "coveralls": "^3.1.0",
+    "data-uri-to-buffer": "^3.0.1",
     "delay": "^5.0.0",
+    "esbuild": "^0.12.16",
+    "fetch-blob": "^3.1.2",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
     "mocha": "^8.3.2",
     "p-timeout": "^5.0.0",
     "tsd": "^0.14.0",
     "xo": "^0.39.1"
-  },
-  "dependencies": {
-    "data-uri-to-buffer": "^3.0.1",
-    "fetch-blob": "^3.1.2"
   },
   "tsd": {
     "cwd": "@types",


### PR DESCRIPTION
**THIS IS A PROPOSAL**

As explained in #1226, the fact that `node-fetch` v3.0.0-beta.10 is now pure ESM cause multiple problems with existing codebases.

In JavaScript codebases, we need to use the async `import()` which can create a lot of changes.
In TypeScript codebases (with cjs module mode), it is impossible to use `node-fetch` anymore.

I think that ESM is the future but it is not as stable as we think and it is not ready to be used everywhere.
The best way to ensure that all existing codebases can migrate to v3 is to provide both `cjs` and `esm` versions of this module.

For this, I introduced `esbuild` which can transpile ESM to CJS and also can bundle the package.

You can say: "node does not need packages to be bundled", which is true.
However, bundling is a good practice to reduce the module loading time, disk operations, memory footprint, etc.
It can also be used to bundle internal dependencies and so reduce the npm dependency tree (reduce install time, disk operations, memory footprint, npm hell, etc.).

**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [X] Other, please explain:
    - allow both esm and cjs exports
    - reduce module loading time
    - reduce disk operations
    - reduce module memory footprint

**What changes did you make? (provide an overview)**

- use esbuild to bundle module in esm and cjs format
- bundle dependencies to reduce module size
- use package exports to automatically select the appropriate version
- add build step to prepublishOnly
- add build step to ci

**Which issue (if any) does this pull request address?**

#1226 
#1217

**Is there anything you'd like reviewers to know?**

In this implementation, I bundle both `data-uri-to-buffer` and `fetch-blob` into the final result allowing us to be dependency free.

I think `data-uri-to-buffer` is safe to bundle because it's an internal dependency.
However, I think `fetch-blob` should not be bundled because it could be used by the consumer.

What do you think?

*Note 1: If we do not want to bundle `fetch-blob`, we have to provide a CJS export for it.*
*Note 2: If we do not bundle `fetch-blob`, the install size will be very large as mentioned by @akaupi in #1217. Maybe we could make fetch-blob dependency free by using `esbuild` to bundle `web-streams-polyfill` .*