### PR TITLE
docs: Add example for loading ESM from CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ if (!globalThis.fetch) {
 
 ```js
 // mod.cjs
-const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args));
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 ```
 
 ## Upgrading

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ if (!globalThis.fetch) {
 }
 ```
 
-`node-fetch` is an ESM-only module - you are not able to import it with `require`. If you are unable to use ESM in your project you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
+`node-fetch` is an ESM-only module - you are not able to import it with `require`. We recommend you stay on v2 which is built with CommonJS unless you use ESM yourself. We will continue to publish critical bug fixes for it.
+
+Alternatively, you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
 
 ```js
 // mod.cjs
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 ```
-
-Alternatively, you can stay on v2 which is built with CommonJS.
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ if (!globalThis.fetch) {
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 ```
 
+The alternative is to stick with the `@2.x` branch that is built with cjs
+`npm install node-fetch@2`
+
 ## Upgrading
 
 Using an old version of node-fetch? Check out the following files:

--- a/README.md
+++ b/README.md
@@ -124,9 +124,7 @@ if (!globalThis.fetch) {
 }
 ```
 
-Stuck with commonjs and can't use ESM imports?
-This is a ESM-only module. Using require to load an ES module is not supported because ES modules have asynchronous execution. Instead, use `import()` to lazy load an ES module from a CommonJS module only when needed.
-It can improve startup performance
+`node-fetch` is an ESM-only module - you are not able to import it with `require`. If you are unable to use ESM in your project you can use the async `import()` from CommonJS to load `node-fetch` asynchronously:
 
 ```js
 // mod.cjs

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ if (!globalThis.fetch) {
 }
 ```
 
+Stuck with commonjs and can't use ESM imports?
+This is a ESM-only module. Using require to load an ES module is not supported because ES modules have asynchronous execution. Instead, use `import()` to lazy load an ES module from a CommonJS module only when needed.
+It can improve startup performance
+
+```js
+// mod.cjs
+const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args));
+```
+
 ## Upgrading
 
 Using an old version of node-fetch? Check out the following files:

--- a/README.md
+++ b/README.md
@@ -124,15 +124,14 @@ if (!globalThis.fetch) {
 }
 ```
 
-`node-fetch` is an ESM-only module - you are not able to import it with `require`. If you are unable to use ESM in your project you can use the async `import()` from CommonJS to load `node-fetch` asynchronously:
+`node-fetch` is an ESM-only module - you are not able to import it with `require`. If you are unable to use ESM in your project you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
 
 ```js
 // mod.cjs
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 ```
 
-The alternative is to stick with the `@2.x` branch that is built with cjs
-`npm install node-fetch@2`
+Alternatively, you can stay on v2 which is built with CommonJS.
 
 ## Upgrading
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ## v3.0.0-beta.10
 
-- **Breaking:** minimum supported Node.js version is now 12.8.
+- **Breaking:** minimum supported Node.js version is now 12.20.
 - **Breaking:** node-fetch is now a pure ESM module.
 - Other: update readme to inform users about ESM.
 - Other: update dependencies.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes will be recorded here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] yyyy-mm-dd
 
-- Other: Updated README & v3-upgrade docs (#1236)
+- docs: Add example for loading ESM from CommonJS (#1236)
 
 ## v3.0.0-beta.10
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,12 @@
-Changelog
-=========
+# Changelog
+All notable changes to this project will be documented in this file.
 
-# 3.x release
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] yyyy-mm-dd
+
+- Other: Updated README & v3-upgrade docs (#1236)
 
 ## v3.0.0-beta.10
 
@@ -374,3 +379,5 @@ See [changelog on 1.x branch](https://github.com/node-fetch/node-fetch/blob/1.x/
 ## v0.1
 
 - Major: initial public release
+
+[Unreleased]: https://github.com/node-fetch/node-fetch/compare/v3.0.0-beta.10...HEAD

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -70,8 +70,9 @@ If you want charset encoding detection, please use the [fetch-charset-detection]
 import fetch from 'node-fetch';
 import convertBody from 'fetch-charset-detection';
 
-fetch('https://somewebsite.com').then(res => {
-	const text = convertBody(res.buffer(), res.headers);
+fetch('https://somewebsite.com').then(async res => {
+    const buf = Buffer.from(await res.arrayBuffer());
+	const text = convertBody(buf, res.headers);
 });
 ```
 

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -19,7 +19,7 @@ other comparatively minor modifications.
 
 # Breaking Changes
 
-## Minimum supported Node.js version is now 10.16
+## Minimum supported Node.js version is now 12.20
 
 Since Node.js will deprecate version 8 at the end of 2019, we decided that node-fetch v3.x will not only drop support for Node.js 4 and 6 (which were supported in v2.x), but also for Node.js 8. We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
 

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -38,8 +38,8 @@ const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args)
 Since this was never part of the fetch specification, it was removed. AbortSignal offers a more fine grained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/Richienb/timeout-signal) as a workaround:
 
 ```js
-const timeoutSignal = require('timeout-signal');
-const fetch = require('node-fetch');
+import timeoutSignal from 'timeout-signal';
+import fetch from 'node-fetch';
 
 const {AbortError} = fetch
 
@@ -67,8 +67,8 @@ Prior to v3.x, we included a `browser` field in the package.json file. Since nod
 If you want charset encoding detection, please use the [fetch-charset-detection] package ([documentation][fetch-charset-detection-docs]).
 
 ```js
-const fetch = require('node-fetch');
-const convertBody = require('fetch-charset-detection');
+import fetch from 'node-fetch';
+import convertBody from 'fetch-charset-detection';
 
 fetch('https://somewebsite.com').then(res => {
 	const text = convertBody(res.buffer(), res.headers);
@@ -80,7 +80,7 @@ fetch('https://somewebsite.com').then(res => {
 When attempting to parse invalid json via `res.json()`, a `SyntaxError` will now be thrown instead of a `FetchError` to align better with the spec.
 
 ```js
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 
 fetch('https://somewebsitereturninginvalidjson.com').then(res => res.json())
 // Throws 'Uncaught SyntaxError: Unexpected end of JSON input' or similar.

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -71,8 +71,8 @@ import fetch from 'node-fetch';
 import convertBody from 'fetch-charset-detection';
 
 fetch('https://somewebsite.com').then(async res => {
-    const buf = Buffer.from(await res.arrayBuffer());
-	const text = convertBody(buf, res.headers);
+    const buf = await res.arrayBuffer();
+    const text = convertBody(buf, res.headers);
 });
 ```
 

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -21,21 +21,21 @@ other comparatively minor modifications.
 
 ## Minimum supported Node.js version is now 12.20
 
-Since Node.js deprecated version 10 in May 2020, we decided that node-fetch v3.x will drop support for Node.js 4, 6, 8, and 10 (which were supported in v2.x). We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
+Since Node.js 10 has been deprecated since May 2020, we have decided that node-fetch v3 will drop support for Node.js 4, 6, 8, and 10 (which were previously supported). We strongly encourage you to upgrade if you still haven't done so. Check out the Node.js official [LTS plan] for more information.
 
 ## Converted to ES Module
 
-This module was converted to be a ESM only package in version `@3.0.0-beta.10`
+This module was converted to be a ESM only package in version `3.0.0-beta.10`.
 Using require to load an ES module is not supported because ES modules have asynchronous execution. Instead, use import() to load an ES module from a CommonJS module.
 
 ```js
 // mod.cjs
-const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args));
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 ```
 
 ## The `timeout` option was removed.
 
-Since this was never part of the fetch specification, it was removed. AbortSignal offers a more fine grained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/Richienb/timeout-signal) as a workaround:
+Since this was never part of the fetch specification, it was removed. AbortSignal offers more fine grained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/node-fetch/timeout-signal) as a workaround:
 
 ```js
 import timeoutSignal from 'timeout-signal';

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -23,6 +23,16 @@ other comparatively minor modifications.
 
 Since Node.js will deprecate version 8 at the end of 2019, we decided that node-fetch v3.x will not only drop support for Node.js 4 and 6 (which were supported in v2.x), but also for Node.js 8. We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
 
+## Converted to ES Module
+
+This module was converted to be a ESM only package in version `@3.0.0-beta.10`
+Using require to load an ES module is not supported because ES modules have asynchronous execution. Instead, use import() to load an ES module from a CommonJS module.
+
+```js
+// mod.cjs
+const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args));
+```
+
 ## The `timeout` option was removed.
 
 Since this was never part of the fetch specification, it was removed. AbortSignal offers a more finegrained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/Richienb/timeout-signal) as a workaround:

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -21,7 +21,7 @@ other comparatively minor modifications.
 
 ## Minimum supported Node.js version is now 12.20
 
-Since Node.js will deprecate version 8 at the end of 2019, we decided that node-fetch v3.x will not only drop support for Node.js 4 and 6 (which were supported in v2.x), but also for Node.js 8. We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
+Since Node.js deprecated version 10 in May 2020, we decided that node-fetch v3.x will drop support for Node.js 4, 6, 8, and 10 (which were supported in v2.x). We strongly encourage you to upgrade, if you still haven't done so. Check out Node.js' official [LTS plan] for more information on Node.js' support lifetime.
 
 ## Converted to ES Module
 

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -26,7 +26,9 @@ Since Node.js 10 has been deprecated since May 2020, we have decided that node-f
 ## Converted to ES Module
 
 This module was converted to be a ESM only package in version `3.0.0-beta.10`.
-Using require to load an ES module is not supported because ES modules have asynchronous execution. Instead, use import() to load an ES module from a CommonJS module.
+`node-fetch` is an ESM-only module - you are not able to import it with `require`. We recommend you stay on v2 which is built with CommonJS unless you use ESM yourself. We will continue to publish critical bug fixes for it.
+
+Alternatively, you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
 
 ```js
 // mod.cjs

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -35,7 +35,7 @@ const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args)
 
 ## The `timeout` option was removed.
 
-Since this was never part of the fetch specification, it was removed. AbortSignal offers a more finegrained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/Richienb/timeout-signal) as a workaround:
+Since this was never part of the fetch specification, it was removed. AbortSignal offers a more fine grained control of request timeouts, and is standardized in the Fetch spec. For convenience, you can use [timeout-signal](https://github.com/Richienb/timeout-signal) as a workaround:
 
 ```js
 const timeoutSignal = require('timeout-signal');


### PR DESCRIPTION
## Purpose
Few ppl started complaining about beta-10 going ESM and are unable to load it. The purpose of this PR is to provide them a alternative method to load ESM modules from CJS 

## Changes
Have only updated some documents and suggested this way of loading fetch:

```js
// mod.cjs
const fetch = (...args) => import('node-fetch').then(mod => mod.default(...args));
```

## Additional information
There are both pro & cons with ESM. 
Bundle all dependencies and having own instances is not desirable. It can make working with different whatwg:streams versions incompatible

- [Dual Package Hazard](https://github.com/GeoffreyBooth/dual-package-hazard)
- [Node Modules at War: Why CommonJS and ES Modules Can’t Get Along](https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1)
- https://github.com/MattiasBuelens/web-streams-polyfill/issues/70#issuecomment-851058462
- [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)
  - [dual package downsides](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#gistcomment-3850849)
___

- [x] I prefixed the PR-title with `docs: `
- [x] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [x] I updated ./docs/v3-UPGRADE-GUIDE
- [x] I updated the README.md
- [ ] <s>Should maybe link to a ESM upgrade guide blog/article of how to upgrade a cjs package to esm and how to use different compilers? ...any suggestions?</s> can do this later...

___

- Address #1234
- Address #1226
- Address #1227
- Address #1230
- Address node-fetch/fetch-blob#107
- fixes #1216