### PR TITLE
V3 stable release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes will be recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] yyyy-mm-dd
+## v3.0.0
 
+- other: Marking v3 as stable
 - docs: Add example for loading ESM from CommonJS (#1236)
 
 ## v3.0.0-beta.10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0",
   "description": "A light-weight module that brings Fetch API to node.js",
   "main": "./src/index.js",
   "sideEffects": false,


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Going out of beta and marking v3 as stable

## Changes

package.json version + changelog only

## Additional information

Have kind of forgot what the procedure is to release something on github/npm 
is there some auto release to npm when a github tag is generated or something?
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated ./docs/CHANGELOG.md
- [ ] Add this to [DefinitelyTyped/DefinitelyTyped/master/notNeededPackages.json](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/notNeededPackages.json) in a draft PR since we now ship the typings.
- [ ] After merge: 
  - [ ] release to npm
  - [ ] tag a new version on github

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #668