### PR TITLE
Fix octocat image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ import fetch from 'node-fetch';
 
 const streamPipeline = promisify(pipeline);
 
-const response = await fetch('https://octodex.github.com/images/Fintechtocat.png');
+const response = await fetch('https://github.githubassets.com/images/modules/logos_page/Octocat.png');
 
 if (!response.ok) throw new Error(`unexpected response ${response.statusText}`);
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ import fetch from 'node-fetch';
 
 const streamPipeline = promisify(pipeline);
 
-const response = await fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png');
+const response = await fetch('https://octodex.github.com/images/Fintechtocat.png');
 
 if (!response.ok) throw new Error(`unexpected response ${response.statusText}`);
 


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

When i try to copy and paste the example code from https://github.com/node-fetch/node-fetch#streams, i got error and turns out the image link for https://assets-cdn.github.com/images/modules/logos_page/Octocat.png is dead. This PR just replace the image with new one, same as buffer example.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
