### PR TITLE
chore: remove triple-slash directives from typings (#1285)

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-/// <reference lib="dom" />
 
 import {Agent} from 'http';
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Remove the `dom` reference triple-slash directive from the typings file which pollutes the global ambient declarations with DOM types.

**Which issue (if any) does this pull request address?**
- fix #1285

**Is there anything you'd like reviewers to know?**
