### PR TITLE
feat: convert to ESM/CJS hybrid package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# CJS generated output
+cjs
+
 # Sketch temporary file
 ~*.sketch
 

--- a/README.md
+++ b/README.md
@@ -126,14 +126,7 @@ if (!globalThis.fetch) {
 }
 ```
 
-`node-fetch` is an ESM-only module - you are not able to import it with `require`. We recommend you stay on v2 which is built with CommonJS unless you use ESM yourself. We will continue to publish critical bug fixes for it.
-
-Alternatively, you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
-
-```js
-// mod.cjs
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-```
+`node-fetch` supports both ESM and CJS import syntax however this support may be removed in future major version of `node-fetch` and users should swap to the ESM only usage as soon as they are able.
 
 ## Upgrading
 

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -23,17 +23,11 @@ other comparatively minor modifications.
 
 Since Node.js 10 has been deprecated since May 2020, we have decided that node-fetch v3 will drop support for Node.js 4, 6, 8, and 10 (which were previously supported). We strongly encourage you to upgrade if you still haven't done so. Check out the Node.js official [LTS plan] for more information.
 
-## Converted to ES Module
+## Converted to ESM/CJS hybrid package
 
-This module was converted to be a ESM only package in version `3.0.0-beta.10`.
-`node-fetch` is an ESM-only module - you are not able to import it with `require`. We recommend you stay on v2 which is built with CommonJS unless you use ESM yourself. We will continue to publish critical bug fixes for it.
+This module was converted to be an ESM/CJS hybrid package in version `3.1.0` with the source written in ESM and transpiled to CJS using `esbuild`.  Version `3.0.0` was released as ESM only and will not be maintained in the future.
 
-Alternatively, you can use the async `import()` function from CommonJS to load `node-fetch` asynchronously:
-
-```js
-// mod.cjs
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-```
+Maintainers of this library plan to remove CJS support in a future major version so users of `node-fetch` should move to the ESM syntax as soon as possible to avoid future breaking issues.
 
 ## The `timeout` option was removed.
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,17 @@
   "name": "node-fetch",
   "version": "3.0.0",
   "description": "A light-weight module that brings Fetch API to node.js",
-  "main": "./src/index.js",
+  "main": "./cjs/index.js",
+  "module": "./src/index.js",
+  "exports": {
+    "import": "./src/index.js",
+    "require": "./cjs/index.js"
+  },
   "sideEffects": false,
   "type": "module",
   "files": [
     "src",
+    "cjs",
     "@types/index.d.ts"
   ],
   "types": "./@types/index.d.ts",
@@ -14,6 +20,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
+    "prepack": "esbuild src/*.js src/**/*.js --outdir=cjs --sourcemap --format=cjs",
     "test": "mocha",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "test-types": "tsd",
@@ -54,6 +61,7 @@
     "chai-string": "^1.5.0",
     "coveralls": "^3.1.0",
     "delay": "^5.0.0",
+    "esbuild": "^0.12.27",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
     "mocha": "^8.3.2",
@@ -77,7 +85,8 @@
       "browser"
     ],
     "ignores": [
-      "example.js"
+      "example.js",
+      "cjs"
     ],
     "rules": {
       "complexity": 0,


### PR DESCRIPTION
As outlined in #1263, the NodeJS ecosystem is not yet prepared for a package as major as `node-fetch` being ESM only.

This PR adds cross transpilation of the 3.0.0 ESM version of `node-fetch` using `esbuild` as a `prepack` step before publishing and configuration in the package.json to allow for both styles of imports.

For ESM only packages that use `node-fetch`, they should be able to 'tree shake' the CJS files so they don't impact application size.

For CJS packages, they can continue to use `node-fetch` as they originally did with the understanding that in the future this support could be removed.

I have updated documentation to reflect the change.

This should allow abandonment of the 2.x branch.