### PR TITLE
fix: properly encode url with unicode characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 # 2.x release
 
+## v2.6.3
+
+- Fix: properly encode url with unicode characters
+
 ## v2.6.2
 
 - Fix: used full filename for main in package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-fetch",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "description": "A light-weight module that brings window.fetch to node.js",
     "main": "lib/index.js",
     "browser": "./browser.js",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "url": "https://github.com/bitinn/node-fetch/issues"
     },
     "homepage": "https://github.com/bitinn/node-fetch",
+    "dependencies": {
+        "whatwg-url": "^5.0.0"
+    },
     "devDependencies": {
         "@ungap/url-search-params": "^0.1.2",
         "abort-controller": "^1.1.0",
@@ -60,7 +63,6 @@
         "rollup": "^0.63.4",
         "rollup-plugin-babel": "^3.0.7",
         "string-to-arraybuffer": "^1.0.2",
-        "teeny-request": "3.7.0",
-        "whatwg-url": "^5.0.0"
+        "teeny-request": "3.7.0"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,11 @@
 import isBuiltin from 'is-builtin-module';
 import babel from 'rollup-plugin-babel';
+import packageJson from './package.json';
 import tweakDefault from './build/rollup-plugin';
 
 process.env.BABEL_ENV = 'rollup';
+
+const dependencies = Object.keys(packageJson.dependencies);
 
 export default {
   input: 'src/index.js',
@@ -18,6 +21,6 @@ export default {
     tweakDefault()
   ],
   external: function (id) {
-    return isBuiltin(id);
+    return dependencies.includes(id) || isBuiltin(id);
   }
 };

--- a/test/server.js
+++ b/test/server.js
@@ -32,7 +32,7 @@ export default class TestServer {
 	}
 
 	router(req, res) {
-		let p = parse(req.url).pathname;
+		let p = decodeURIComponent(parse(req.url).pathname);
 
 		if (p === '/hello') {
 			res.statusCode = 200;
@@ -383,6 +383,12 @@ export default class TestServer {
 				}));
 			});
 			req.pipe(parser);
+		}
+
+		if (p === '/issues/1290/ひらがな') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/plain');
+			res.end('Success');
 		}
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2845,3 +2845,25 @@ describe('external encoding', () => {
 		});
 	});
 });
+
+describe('issue #1290', function() {
+	it('should handle escaped unicode in URLs', () => {
+		const url = `${base}issues/1290/%E3%81%B2%E3%82%89%E3%81%8C%E3%81%AA`;
+		return fetch(url).then((res) => {
+			expect(res.status).to.equal(200);
+			return res.text().then(result => {
+				expect(result).to.equal('Success');
+			});
+		});
+	});
+
+	it('should handle unicode in URLs', () => {
+		const url = `${base}issues/1290/ひらがな`;
+		return fetch(url).then((res) => {
+			expect(res.status).to.equal(200);
+			return res.text().then(result => {
+				expect(result).to.equal('Success');
+			});
+		});
+	});
+});


### PR DESCRIPTION
**What is the purpose of this pull request?**

- Documentation update
- [x] Bug fix
- New feature
- Other, please explain:

**What changes did you make? (provide an overview)**

I've added a call to `encodeURI` before parsing a passed in string as an url

**Which issue (if any) does this pull request address?**

#1290 

**Is there anything you'd like reviewers to know?**

This is basically a backport of #701, but keeps the old code path for arbitrary URLs on the `Request` object which was supported in 2.x