### PR TITLE
fix: import whatwg-url in a way compatible with ESM Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 # 2.x release
 
+## v2.6.5
+
+- Fix: import `whatwg-url` in a way compatible with ESM
+
 ## v2.6.4
 
 - Hotfix: fix v2.6.3 that did not sending query params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-fetch",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "A light-weight module that brings window.fetch to node.js",
     "main": "lib/index.js",
     "browser": "./browser.js",

--- a/src/request.js
+++ b/src/request.js
@@ -9,11 +9,12 @@
 
 import Url from 'url';
 import Stream from 'stream';
-import {URL} from 'whatwg-url';
+import whatwgUrl from 'whatwg-url';
 import Headers, { exportNodeCompatibleHeaders } from './headers.js';
 import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const INTERNALS = Symbol('Request internals');
+const URL = whatwgUrl.URL;
 
 // fix an issue where "format", "parse" aren't a named export for node <10
 const parse_url = Url.parse;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- Documentation update
- [x] Bug fix
- New feature
- Other, please explain:

**What changes did you make? (provide an overview)**

I imported `whatwg-url` in a way that is compatible with Node.js running in ESM mode.

**Which issue (if any) does this pull request address?**

https://github.com/node-fetch/node-fetch/commit/ace7536c955556be742d9910566738630cc3c2a6#r56836783

**Is there anything you'd like reviewers to know?**

n/a

closes #1305 