### PR TITLE
2.x: Specify encoding as an optional peer dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
     "dependencies": {
         "whatwg-url": "^5.0.0"
     },
+    "peerDependencies": { 
+        "encoding": "*"
+    },
+    "peerDependenciesMeta": {
+        "encoding": {
+            "optional": true
+        }
+    },
     "devDependencies": {
         "@ungap/url-search-params": "^0.1.2",
         "abort-controller": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "whatwg-url": "^5.0.0"
     },
     "peerDependencies": { 
-        "encoding": "*"
+        "encoding": "^0.1.0"
     },
     "peerDependenciesMeta": {
         "encoding": {


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

I installed node-fetch 2.x on my project with Yarn 2 (aka Yarn berry). When I call `require('node-fetch')`, I get this warning message:

```
(node:22404) [MODULE_NOT_FOUND] Error: node-fetch tried to access encoding, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

It seems that `encoding` package is optional and only used in `body.textConverted()` method (discussed in #412).

So I added the following to `package.json` of node-fetch:

```json
"peerDependencies": { 
    "encoding": "*"
},
"peerDependenciesMeta": {
    "encoding": {
        "optional": true
    }
}
```

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
