### PR TITLE
fix(Types): make `Body.json()` method generic

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -107,7 +107,7 @@ declare class BodyMixin {
 	buffer(): Promise<Buffer>;
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;
-	json(): Promise<unknown>;
+	json<T>(): Promise<T>;
 	text(): Promise<string>;
 }
 

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -29,6 +29,14 @@ async function run() {
 
 	// Test JSON, returns unknown
 	expectType<unknown>(await getResponse.json());
+	// Test JSON with generics, returns T
+	interface T {
+		userId: number,
+		id: number,
+		title: string,
+		body: string
+	}
+	expectType<T>(await (await fetch('https://jsonplaceholder.typicode.com/posts/1')).json())
 
 	// Headers iterable
 	expectType<Headers>(getResponse.headers);


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain:

Makes the `json` method generic. This will allow users to tell tsc the return type of the method. It's opt-in, which means if no type is provided, the return type will remain `unknown`

**What changes did you make?**

Turned `BodyMixin#json` into a generic method.
```ts
const a = await res.json(); // 'a' is unknown

interface User {
 name: string;
}
const b = await res.json<User>(); // 'b' is of type User
```
**Which issue (if any) does this pull request address?**

Lack of IntelliSense due to return type of `json` being `unknown`. It still defaults to `unknown` but the user can opt-in by providing a return type for the method.
