### PR TITLE
docs(Headers): Add default Host request header to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ If no values are set, the following request headers will be sent automatically:
 | `Accept`            | `*/*`                                                  |
 | `Connection`        | `close` _(when no `options.agent` is present)_         |
 | `Content-Length`    | _(automatically calculated, if possible)_              |
+| `Host`              | _(host and port information from the target URI)_      |
 | `Transfer-Encoding` | `chunked` _(when `req.body` is a stream)_              |
 | `User-Agent`        | `node-fetch`                                           |
 


### PR DESCRIPTION
Mention the Host header in the default request headers table.

According to the standard [RFC 7230 Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing](https://httpwg.org/specs/rfc7230.html#header.host)
> "A client MUST send a Host header field in all HTTP/1.1 request messages."

**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**
Add information to the documentation.