### PR TITLE
Disable chunked encoding fix with keep-alive requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ console.log(data);
 
 node-fetch also support form-data but it's now discouraged due to not being spec-compliant and needs workarounds to function - which we hope to remove one day
 
+<a id="request-cancellation-with-abort-signal"></a>
+
 ### Request cancellation with AbortSignal
 
 You may cancel requests with `AbortController`. A suggested implementation is [`abort-controller`](https://www.npmjs.com/package/abort-controller).
@@ -531,6 +533,8 @@ const options = {
 	}
 };
 ```
+
+*Note on `keepAlive`: be sure to implement request timeouts when using `keepAlive`. Certain fixes for handling premature request closures are not compatible with `keepAlive`, which can result in requests never completing if requests do not have timeouts. See [Request cancellation with AbortSignal](#request-cancellation-with-abort-signal).*
 
 <a id="custom-highWaterMark"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -95,9 +95,12 @@ export default async function fetch(url, options_) {
 			finalize();
 		});
 
-		fixResponseChunkedTransferBadEnding(request_, error => {
-			response.body.destroy(error);
-		});
+		if (!request_.shouldKeepAlive) {
+			// fixResponseChunkedTransferBadEnding is not compatible with pipelined/keep-alive requests
+			fixResponseChunkedTransferBadEnding(request_, error => {
+				response.body.destroy(error);
+			});
+		}
 
 		/* c8 ignore next 18 */
 		if (process.version < 'v14') {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

This change disables `fixResponseChunkedTransferBadEnding` when the request is a keep-alive request.

**Which issue (if any) does this pull request address?**

#1295

**Is there anything you'd like reviewers to know?**
