### PR TITLE
Implement Happy Eyeballs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --async-stack-traces",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "test-types": "tsd",
     "lint": "xo"
@@ -56,6 +56,7 @@
     "delay": "^5.0.0",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
+    "happy-eyeballs": "^0.0.6",
     "mocha": "^8.3.2",
     "p-timeout": "^5.0.0",
     "tsd": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "delay": "^5.0.0",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
-    "happy-eyeballs": "^0.0.11",
     "mocha": "^8.3.2",
     "p-timeout": "^5.0.0",
     "tsd": "^0.14.0",
@@ -64,7 +63,8 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^3.0.1",
-    "fetch-blob": "^3.1.2"
+    "fetch-blob": "^3.1.2",
+    "happy-eyeballs": "^0.0.13"
   },
   "tsd": {
     "cwd": "@types",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "delay": "^5.0.0",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
-    "happy-eyeballs": "^0.0.8",
+    "happy-eyeballs": "^0.0.11",
     "mocha": "^8.3.2",
     "p-timeout": "^5.0.0",
     "tsd": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "test": "mocha --async-stack-traces",
+    "test": "mocha",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "test-types": "tsd",
     "lint": "xo"
@@ -56,7 +56,7 @@
     "delay": "^5.0.0",
     "form-data": "^4.0.0",
     "formdata-node": "^3.5.4",
-    "happy-eyeballs": "^0.0.6",
+    "happy-eyeballs": "^0.0.8",
     "mocha": "^8.3.2",
     "p-timeout": "^5.0.0",
     "tsd": "^0.14.0",

--- a/src/agent.js
+++ b/src/agent.js
@@ -1,0 +1,14 @@
+import { createConnection } from 'happy-eyeballs';
+import {Agent as HttpAgent} from 'http';
+import {Agent as HttpsAgent} from 'https';
+
+class HappyEyeballsHttpAgent extends HttpAgent {
+  createConnection = createConnection;
+}
+
+class HappyEyeballsHttpsAgent extends HttpsAgent {
+  createConnection = createConnection;
+}
+
+export const httpAgent = new HappyEyeballsHttpAgent();
+export const httpsAgent = new HappyEyeballsHttpsAgent();

--- a/src/agent.js
+++ b/src/agent.js
@@ -2,13 +2,13 @@ import { createConnection } from 'happy-eyeballs';
 import {Agent as HttpAgent} from 'http';
 import {Agent as HttpsAgent} from 'https';
 
-class HappyEyeballsHttpAgent extends HttpAgent {
+export class DefaultHttpAgent extends HttpAgent {
   createConnection = createConnection;
 }
 
-class HappyEyeballsHttpsAgent extends HttpsAgent {
+export class DefaultHttpsAgent extends HttpsAgent {
   createConnection = createConnection;
 }
 
-export const httpAgent = new HappyEyeballsHttpAgent();
-export const httpsAgent = new HappyEyeballsHttpsAgent();
+export const defaultHttpAgent = new DefaultHttpAgent();
+export const defaultHttpsAgent = new DefaultHttpsAgent();

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,7 @@ export default async function fetch(url, options_) {
 							follow: request.follow,
 							counter: request.counter + 1,
 							agent: request.agent,
+							createConnection: request.createConnection,
 							compress: request.compress,
 							method: request.method,
 							body: clone(request),

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,6 @@ export default async function fetch(url, options_) {
 							follow: request.follow,
 							counter: request.counter + 1,
 							agent: request.agent,
-							createConnection: request.createConnection,
 							compress: request.compress,
 							method: request.method,
 							body: clone(request),

--- a/src/request.js
+++ b/src/request.js
@@ -12,6 +12,7 @@ import Headers from './headers.js';
 import Body, {clone, extractContentType, getTotalBytes} from './body.js';
 import {isAbortSignal} from './utils/is.js';
 import {getSearch} from './utils/get-search.js';
+import { httpAgent, httpsAgent } from './agent.js';
 
 const INTERNALS = Symbol('Request internals');
 
@@ -105,7 +106,10 @@ export default class Request extends Body {
 		this.follow = init.follow === undefined ? (input.follow === undefined ? 20 : input.follow) : init.follow;
 		this.compress = init.compress === undefined ? (input.compress === undefined ? true : input.compress) : init.compress;
 		this.counter = init.counter || input.counter || 0;
-		this.agent = init.agent || input.agent;
+		this.agent = init.agent || input.agent || (parsedURL.protocol === 'https:' ? httpsAgent : httpAgent);
+		this.family = 0;
+		this.verbatim = true;
+		this.all = true;
 		this.highWaterMark = init.highWaterMark || input.highWaterMark || 16384;
 		this.insecureHTTPParser = init.insecureHTTPParser || input.insecureHTTPParser || false;
 	}
@@ -219,7 +223,11 @@ export const getNodeRequestOptions = request => {
 		method: request.method,
 		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
 		insecureHTTPParser: request.insecureHTTPParser,
-		agent
+		agent,
+		createConnection,
+		verbatim: true,
+		family: 0,
+		all: true,
 	};
 
 	return {
@@ -227,3 +235,4 @@ export const getNodeRequestOptions = request => {
 		options
 	};
 };
+

--- a/src/request.js
+++ b/src/request.js
@@ -107,9 +107,6 @@ export default class Request extends Body {
 		this.compress = init.compress === undefined ? (input.compress === undefined ? true : input.compress) : init.compress;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent || (parsedURL.protocol === 'https:' ? defaultHttpsAgent : defaultHttpAgent);
-		this.family = 0;
-		this.verbatim = true;
-		this.all = true;
 		this.highWaterMark = init.highWaterMark || input.highWaterMark || 16384;
 		this.insecureHTTPParser = init.insecureHTTPParser || input.insecureHTTPParser || false;
 	}
@@ -223,10 +220,7 @@ export const getNodeRequestOptions = request => {
 		method: request.method,
 		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
 		insecureHTTPParser: request.insecureHTTPParser,
-		agent,
-		verbatim: true,
-		family: 0,
-		all: true,
+		agent
 	};
 
 	return {

--- a/src/request.js
+++ b/src/request.js
@@ -12,7 +12,7 @@ import Headers from './headers.js';
 import Body, {clone, extractContentType, getTotalBytes} from './body.js';
 import {isAbortSignal} from './utils/is.js';
 import {getSearch} from './utils/get-search.js';
-import { httpAgent, httpsAgent } from './agent.js';
+import { defaultHttpAgent, defaultHttpsAgent } from './agent.js';
 
 const INTERNALS = Symbol('Request internals');
 
@@ -106,7 +106,7 @@ export default class Request extends Body {
 		this.follow = init.follow === undefined ? (input.follow === undefined ? 20 : input.follow) : init.follow;
 		this.compress = init.compress === undefined ? (input.compress === undefined ? true : input.compress) : init.compress;
 		this.counter = init.counter || input.counter || 0;
-		this.agent = init.agent || input.agent || (parsedURL.protocol === 'https:' ? httpsAgent : httpAgent);
+		this.agent = init.agent || input.agent || (parsedURL.protocol === 'https:' ? defaultHttpsAgent : defaultHttpAgent);
 		this.family = 0;
 		this.verbatim = true;
 		this.all = true;
@@ -224,7 +224,6 @@ export const getNodeRequestOptions = request => {
 		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
 		insecureHTTPParser: request.insecureHTTPParser,
 		agent,
-		createConnection,
 		verbatim: true,
 		family: 0,
 		all: true,

--- a/test/main.js
+++ b/test/main.js
@@ -5,25 +5,23 @@ import http from 'http';
 import fs from 'fs';
 import stream from 'stream';
 import path from 'path';
-import dns from 'dns';
-import net from 'net';
-import { once } from 'events';
+import {lookup} from 'dns';
 import vm from 'vm';
 import chai from 'chai';
 import chaiPromised from 'chai-as-promised';
 import chaiIterator from 'chai-iterator';
 import chaiString from 'chai-string';
 import FormData from 'form-data';
-import { FormData as FormDataNode } from 'formdata-node';
+import {FormData as FormDataNode} from 'formdata-node';
 import delay from 'delay';
 import AbortControllerMysticatea from 'abort-controller';
 import abortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
-import { callbackify, promisify } from 'util';
-import { DefaultHttpAgent, DefaultHttpsAgent } from '../src/agent.js';
+import {promisify} from 'util';
+import {DefaultHttpAgent} from '../src/agent.js';
 
 // Test subjects
 import Blob from 'fetch-blob';
-import { fileFromSync } from 'fetch-blob/from.js';
+import {fileFromSync} from 'fetch-blob/from.js';
 
 import fetch, {
 	FetchError,
@@ -31,18 +29,18 @@ import fetch, {
 	Request,
 	Response
 } from '../src/index.js';
-import { FetchError as FetchErrorOrig } from '../src/errors/fetch-error.js';
-import HeadersOrig, { fromRawHeaders } from '../src/headers.js';
+import {FetchError as FetchErrorOrig} from '../src/errors/fetch-error.js';
+import HeadersOrig, {fromRawHeaders} from '../src/headers.js';
 import RequestOrig from '../src/request.js';
 import ResponseOrig from '../src/response.js';
-import Body, { getTotalBytes, extractContentType } from '../src/body.js';
+import Body, {getTotalBytes, extractContentType} from '../src/body.js';
 import TestServer from './utils/server.js';
 import chaiTimeout from './utils/chai-timeout.js';
 
 const AbortControllerPolyfill = abortControllerPolyfill.AbortController;
 
 function isNodeLowerThan(version) {
-	return !~process.version.localeCompare(version, undefined, { numeric: true });
+	return !~process.version.localeCompare(version, undefined, {numeric: true});
 }
 
 const {
@@ -53,7 +51,7 @@ chai.use(chaiPromised);
 chai.use(chaiIterator);
 chai.use(chaiString);
 chai.use(chaiTimeout);
-const { expect } = chai;
+const {expect} = chai;
 
 function streamToPromise(stream, dataHandler) {
 	return new Promise((resolve, reject) => {
@@ -120,7 +118,7 @@ describe('node-fetch', () => {
 		const url = 'http://localhost:50000/';
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
-			.and.include({ type: 'system', code: 'ECONNREFUSED', errno: 'ECONNREFUSED' });
+			.and.include({type: 'system', code: 'ECONNREFUSED', errno: 'ECONNREFUSED'});
 	});
 
 	it('error should contain system error if one occurred', () => {
@@ -207,7 +205,7 @@ describe('node-fetch', () => {
 			return res.json().then(result => {
 				expect(res.bodyUsed).to.be.true;
 				expect(result).to.be.an('object');
-				expect(result).to.deep.equal({ name: 'value' });
+				expect(result).to.deep.equal({name: 'value'});
 			});
 		});
 	});
@@ -215,7 +213,7 @@ describe('node-fetch', () => {
 	it('should send request with custom headers', () => {
 		const url = `${base}inspect`;
 		const options = {
-			headers: { 'x-custom-header': 'abc' }
+			headers: {'x-custom-header': 'abc'}
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -227,7 +225,7 @@ describe('node-fetch', () => {
 	it('should accept headers instance', () => {
 		const url = `${base}inspect`;
 		const options = {
-			headers: new Headers({ 'x-custom-header': 'abc' })
+			headers: new Headers({'x-custom-header': 'abc'})
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -500,7 +498,7 @@ describe('node-fetch', () => {
 	it('should follow redirect code 301 and keep existing headers', () => {
 		const url = `${base}redirect/301`;
 		const options = {
-			headers: new Headers({ 'x-custom-header': 'abc' })
+			headers: new Headers({'x-custom-header': 'abc'})
 		};
 		return fetch(url, options).then(res => {
 			expect(res.url).to.equal(`${base}inspect`);
@@ -919,7 +917,7 @@ describe('node-fetch', () => {
 			.then(res => {
 				expect(res.status).to.equal(200);
 			})
-			.catch(() => { })
+			.catch(() => {})
 			.then(() => {
 				// Wait a few ms to see if a uncaught error occurs
 				setTimeout(() => {
@@ -982,7 +980,7 @@ describe('node-fetch', () => {
 							signal: controller.signal,
 							headers: {
 								'Content-Type': 'application/json',
-								body: JSON.stringify({ hello: 'world' })
+								body: JSON.stringify({hello: 'world'})
 							}
 						}
 					)
@@ -1003,7 +1001,7 @@ describe('node-fetch', () => {
 
 			it('should support multiple request cancellation with signal', () => {
 				const fetches = [
-					fetch(`${base}timeout`, { signal: controller.signal }),
+					fetch(`${base}timeout`, {signal: controller.signal}),
 					fetch(
 						`${base}timeout`,
 						{
@@ -1011,7 +1009,7 @@ describe('node-fetch', () => {
 							signal: controller.signal,
 							headers: {
 								'Content-Type': 'application/json',
-								body: JSON.stringify({ hello: 'world' })
+								body: JSON.stringify({hello: 'world'})
 							}
 						}
 					)
@@ -1074,7 +1072,7 @@ describe('node-fetch', () => {
 			it('should reject response body with AbortError when aborted before stream has been read completely', () => {
 				return expect(fetch(
 					`${base}slow`,
-					{ signal: controller.signal }
+					{signal: controller.signal}
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1090,7 +1088,7 @@ describe('node-fetch', () => {
 			it('should reject response body methods immediately with AbortError when aborted before stream is disturbed', () => {
 				return expect(fetch(
 					`${base}slow`,
-					{ signal: controller.signal }
+					{signal: controller.signal}
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1105,7 +1103,7 @@ describe('node-fetch', () => {
 			it('should emit error event to response body with an AbortError when aborted before underlying stream is closed', done => {
 				expect(fetch(
 					`${base}slow`,
-					{ signal: controller.signal }
+					{signal: controller.signal}
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1120,11 +1118,11 @@ describe('node-fetch', () => {
 			});
 
 			it('should cancel request body of type Stream with AbortError when aborted', () => {
-				const body = new stream.Readable({ objectMode: true });
-				body._read = () => { };
+				const body = new stream.Readable({objectMode: true});
+				body._read = () => {};
 				const promise = fetch(
 					`${base}slow`,
-					{ signal: controller.signal, body, method: 'POST' }
+					{signal: controller.signal, body, method: 'POST'}
 				);
 
 				const result = Promise.all([
@@ -1159,13 +1157,13 @@ describe('node-fetch', () => {
 		() => {
 			it('should remove internal AbortSignal event listener after request is aborted', () => {
 				const controller = new AbortControllerPolyfill();
-				const { signal } = controller;
+				const {signal} = controller;
 
 				setTimeout(() => {
 					controller.abort();
 				}, 20);
 
-				return expect(fetch(`${base}timeout`, { signal }))
+				return expect(fetch(`${base}timeout`, {signal}))
 					.to.eventually.be.rejected
 					.and.be.an.instanceof(Error)
 					.and.have.property('name', 'AbortError')
@@ -1176,11 +1174,11 @@ describe('node-fetch', () => {
 
 			it('should remove internal AbortSignal event listener after request and response complete without aborting', () => {
 				const controller = new AbortControllerPolyfill();
-				const { signal } = controller;
-				const fetchHtml = fetch(`${base}html`, { signal })
+				const {signal} = controller;
+				const fetchHtml = fetch(`${base}html`, {signal})
 					.then(res => res.text());
-				const fetchResponseError = fetch(`${base}error/reset`, { signal });
-				const fetchRedirect = fetch(`${base}redirect/301`, { signal }).then(res => res.json());
+				const fetchResponseError = fetch(`${base}error/reset`, {signal});
+				const fetchRedirect = fetch(`${base}redirect/301`, {signal}).then(res => res.json());
 				return Promise.all([
 					expect(fetchHtml).to.eventually.be.fulfilled.and.equal('<html></html>'),
 					expect(fetchResponseError).to.be.eventually.rejected,
@@ -1200,15 +1198,15 @@ describe('node-fetch', () => {
 
 	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
 		return Promise.all([
-			expect(fetch(`${base}inspect`, { signal: {} }))
+			expect(fetch(`${base}inspect`, {signal: {}}))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal'),
-			expect(fetch(`${base}inspect`, { signal: '' }))
+			expect(fetch(`${base}inspect`, {signal: ''}))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal'),
-			expect(fetch(`${base}inspect`, { signal: Object.create(null) }))
+			expect(fetch(`${base}inspect`, {signal: Object.create(null)}))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal')
@@ -1217,10 +1215,10 @@ describe('node-fetch', () => {
 
 	it('should gracefully handle a nullish signal', () => {
 		return Promise.all([
-			fetch(`${base}hello`, { signal: null }).then(res => {
+			fetch(`${base}hello`, {signal: null}).then(res => {
 				return expect(res.ok).to.be.true;
 			}),
-			fetch(`${base}hello`, { signal: undefined }).then(res => {
+			fetch(`${base}hello`, {signal: undefined}).then(res => {
 				return expect(res.ok).to.be.true;
 			})
 		]);
@@ -1550,7 +1548,7 @@ describe('node-fetch', () => {
 		// Note that fetch simply calls tostring on an object
 		const options = {
 			method: 'POST',
-			body: { a: 1 }
+			body: {a: 1}
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -1571,7 +1569,7 @@ describe('node-fetch', () => {
 
 	it('constructing a Request with URLSearchParams as body should have a Content-Type', () => {
 		const parameters = new URLSearchParams();
-		const request = new Request(base, { method: 'POST', body: parameters });
+		const request = new Request(base, {method: 'POST', body: parameters});
 		expect(request.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded;charset=UTF-8');
 	});
 
@@ -1586,7 +1584,7 @@ describe('node-fetch', () => {
 	// Body should been cloned...
 	it('constructing a Request/Response with URLSearchParams and mutating it should not affected body', () => {
 		const parameters = new URLSearchParams();
-		const request = new Request(`${base}inspect`, { method: 'POST', body: parameters });
+		const request = new Request(`${base}inspect`, {method: 'POST', body: parameters});
 		parameters.append('a', '1');
 		return request.text().then(text => {
 			expect(text).to.equal('');
@@ -1613,7 +1611,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should still recognize URLSearchParams when extended', () => {
-		class CustomSearchParameters extends URLSearchParams { }
+		class CustomSearchParameters extends URLSearchParams {}
 		const parameters = new CustomSearchParameters();
 		parameters.append('a', '1');
 
@@ -1635,7 +1633,7 @@ describe('node-fetch', () => {
 	/* For 100% code coverage, checks for duck-typing-only detection
 	 * where both constructor.name and brand tests fail */
 	it('should still recognize URLSearchParams when extended from polyfill', () => {
-		class CustomPolyfilledSearchParameters extends URLSearchParams { }
+		class CustomPolyfilledSearchParameters extends URLSearchParams {}
 		const parameters = new CustomPolyfilledSearchParameters();
 		parameters.append('a', '1');
 
@@ -1853,7 +1851,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return Promise.all([res.json(), r1.text()]).then(results => {
-				expect(results[0]).to.deep.equal({ name: 'value' });
+				expect(results[0]).to.deep.equal({name: 'value'});
 				expect(results[1]).to.equal('{"name":"value"}');
 			});
 		});
@@ -1864,7 +1862,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return res.json().then(result => {
-				expect(result).to.deep.equal({ name: 'value' });
+				expect(result).to.deep.equal({name: 'value'});
 				return r1.text().then(result => {
 					expect(result).to.equal('{"name":"value"}');
 				});
@@ -1879,7 +1877,7 @@ describe('node-fetch', () => {
 			return r1.text().then(result => {
 				expect(result).to.equal('{"name":"value"}');
 				return res.json().then(result => {
-					expect(result).to.deep.equal({ name: 'value' });
+					expect(result).to.deep.equal({name: 'value'});
 				});
 			});
 		});
@@ -1928,7 +1926,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
 		});
 		return expect(
-			fetch(url, { highWaterMark: 10 }).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
 		).to.timeout;
 	});
 
@@ -1962,7 +1960,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
 		});
 		return expect(
-			fetch(url, { highWaterMark: 10 }).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
 		).not.to.timeout;
 	});
 
@@ -1977,7 +1975,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes((2 * 512 * 1024) - 1));
 		});
 		return expect(
-			fetch(url, { highWaterMark: 512 * 1024 }).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 512 * 1024}).then(res => res.clone().buffer())
 		).not.to.timeout;
 	});
 
@@ -2131,7 +2129,7 @@ describe('node-fetch', () => {
 				method: 'POST',
 				body: blob
 			});
-		}).then(res => res.json()).then(({ body, headers }) => {
+		}).then(res => res.json()).then(({body, headers}) => {
 			expect(body).to.equal('world');
 			expect(headers['content-type']).to.equal(type);
 			expect(headers['content-length']).to.equal(String(length));
@@ -2204,12 +2202,12 @@ describe('node-fetch', () => {
 			await new Promise(resolve => {
 				setTimeout(resolve, 200);
 			});
-			yield { tada: 'yes' };
+			yield {tada: 'yes'};
 		})()));
 
 		return expect(res.text()).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
-			.and.include({ type: 'system' })
+			.and.include({type: 'system'})
 			.and.have.property('message').that.include('Could not create Buffer');
 	});
 
@@ -2220,11 +2218,11 @@ describe('node-fetch', () => {
 			called++;
 
 			// eslint-disable-next-line node/prefer-promises/dns
-			return dns.lookup(hostname, options, callback);
+			return lookup(hostname, options, callback);
 		}
 
-		const agent = http.Agent({ lookup: lookupSpy });
-		return fetch(url, { agent }).then(() => {
+		const agent = http.Agent({lookup: lookupSpy});
+		return fetch(url, {agent}).then(() => {
 			expect(called).to.equal(2);
 		});
 	});
@@ -2237,11 +2235,11 @@ describe('node-fetch', () => {
 			families.push(options.family);
 
 			// eslint-disable-next-line node/prefer-promises/dns
-			return dns.lookup(hostname, {}, callback);
+			return lookup(hostname, {}, callback);
 		}
 
-		const agent = http.Agent({ lookup: lookupSpy, family });
-		return fetch(url, { agent }).then(() => {
+		const agent = http.Agent({lookup: lookupSpy, family});
+		return fetch(url, {agent}).then(() => {
 			expect(families).to.have.length(2);
 			expect(families[0]).to.equal(family);
 			expect(families[1]).to.equal(family);
@@ -2283,7 +2281,7 @@ describe('node-fetch', () => {
 			size: 1024
 		});
 
-		const blobBody = new Blob([bodyContent], { type: 'text/plain' });
+		const blobBody = new Blob([bodyContent], {type: 'text/plain'});
 		const blobRequest = new Request(url, {
 			method: 'POST',
 			body: blobBody,
@@ -2337,6 +2335,93 @@ describe('node-fetch', () => {
 		const res = await fetch(url);
 		expect(res.url).to.equal(`${base}m%C3%B6bius`);
 	});
+
+	const getFakeAddresses = num => {
+		const result = [];
+		while (num--) {
+			result.push(
+				{
+					family: 6,
+					address: 'dead::' + num.toString(16),
+				},
+				{
+					family: 4,
+					address: '123.123.123' + num,
+				},
+			)
+		}
+		return result;
+	};
+	const lookupAsync = promisify(lookup);
+	const mockLookup = fn => async (_hostname, options) => {
+		const real = await lookupAsync(_hostname, {
+			all: true,
+			family: 0,
+			verbatim: true,
+			...options,
+		});
+		if (local.hostname !== _hostname) {
+			return real;
+		}
+		return await fn(real);
+	};
+
+	const mockAgent = options => new DefaultHttpAgent({
+		delay: 1,
+		lookup: lookup,
+		...options,
+	});
+
+	it('should succeed with incorrect addresses prepended to correct', () => {
+		return fetch(`${base}hello`, {
+			agent: mockAgent({
+				lookup: mockLookup(real => [...getFakeAddresses(1), ...real]),
+			})
+		}).then(resp => {
+			expect(resp.status).to.equal(200);
+		});
+	});
+
+	it('fail with all incorrect addresses', () => {
+		// no chance of establishing connection in this time frame
+		return expect(fetch(`${base}hello`, {
+			agent: mockAgent({
+				timeout: 1,
+				delay: 1,
+				lookup: mockLookup(() => getFakeAddresses(20)),
+			}),
+		})).to.eventually.be.rejected;
+	});
+
+	it('should connect when spamming all IPs with many incorrect addresses', async () => {
+		const start = Date.now();
+		const resp = await fetch(`${base}hello`, {
+			agent: mockAgent({
+				lookup: mockLookup(real => [...getFakeAddresses(20), ...real]),
+			}),
+		})
+		expect(await resp.text()).to.equal('world');
+		if (start - Date.now() > 1000) {
+			throw new Error('Could not connect in time.')
+		}
+	});
+
+	it('can abort requests', async () => {
+		const ac = new AbortController();
+		try {
+			ac.abort();
+			await fetch(`${base}hello`, {
+				signal: ac.signal,
+				delay: 1000,
+				agent: mockAgent({
+					lookup: mockLookup(() => getFakeAddresses(1)),
+				}),
+			});
+			throw new Error('Request was not aborted.');
+		} catch (err) {
+			expect(err.name).to.equal('AbortError');
+		}
+	});
 });
 
 describe('node-fetch using IPv6', () => {
@@ -2366,105 +2451,5 @@ describe('node-fetch using IPv6', () => {
 			expect(res.status).to.equal(200);
 			expect(res.statusText).to.equal('OK');
 		});
-	});
-});
-
-describe.only('node-fetch using happy eyeballs (rfc 8305)', () => {
-	const local = new TestServer();
-	let url;
-
-	before(async () => {
-		await local.start();
-		url = new URL(`http://localhost:${local.port}/`);
-	});
-
-
-	after(() => {
-		return local.stop();
-	});
-
-	const getFakeAddresses = num => {
-		const result = [];
-		while (num--) {
-			result.push(
-				{
-					family: 6,
-					address: 'dead::' + num.toString(16),
-				}, {
-				family: 4,
-				address: '192.168.54.' + num,
-			})
-		}
-		return result;
-	};
-	const lookupAsync = promisify(dns.lookup);
-	const mockLookup = fn => callbackify(async (_hostname, options) => {
-		const real = await lookupAsync(_hostname, {
-			all: true,
-			family: 0,
-			verbatim: true,
-			...options,
-		});
-		if (url.hostname !== _hostname) {
-			return real;
-		}
-		return await fn(real);
-	})
-
-	const mockAgent = options => new DefaultHttpAgent({
-		delay: 1,
-		lookup: dns.lookup,
-		...options,
-	});
-
-	it('should succeed with incorrect addresses prepended to correct', () => {
-		return fetch(`${url.href}hello`, {
-			agent: mockAgent({
-				lookup: mockLookup(real => [...getFakeAddresses(1), ...real]),
-			})
-		}).then(resp => {
-			expect(resp.status).to.equal(200);
-		});
-	});
-
-	it('fail with all incorrect addresses', () => {
-		return expect(fetch(`${url.href}hello`, {
-			agent: mockAgent({
-				timeout: 1,
-				delay: 1,
-				lookup: mockLookup(() => getFakeAddresses(20)),
-			}),
-		})).to.eventually.be.rejected
-			.and.have.property('message').that.include('timed out');
-	});
-
-	it('should connect when spamming all IPs with many incorrect addresses', async () => {
-		const start = Date.now();
-		const resp = await fetch(`${url.href}hello`, {
-			agent: mockAgent({
-				lookup: mockLookup(real => [...getFakeAddresses(20), ...real]),
-			}),
-		})
-		expect(await resp.text()).to.equal('world');
-		if (start - Date.now() > 1000) {
-			throw new Error('Could not connect in time.')
-		}
-	});
-
-	it('can abort requests', async () => {
-		const ac = new AbortController();
-		try {
-			ac.abort();
-			await fetch(url.href, {
-				signal: ac.signal,
-				delay: 1000,
-				agent: mockAgent({
-					lookup: mockLookup(() => getFakeAddresses(1)),
-				}),
-			});
-			throw new Error('Request was not aborted.');
-		} catch (err) {
-			expect(err.name).to.equal('AbortError');
-		}
 	});
 });

--- a/test/main.js
+++ b/test/main.js
@@ -14,7 +14,7 @@ import chaiPromised from 'chai-as-promised';
 import chaiIterator from 'chai-iterator';
 import chaiString from 'chai-string';
 import FormData from 'form-data';
-import {FormData as FormDataNode} from 'formdata-node';
+import { FormData as FormDataNode } from 'formdata-node';
 import delay from 'delay';
 import AbortControllerMysticatea from 'abort-controller';
 import abortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
@@ -23,7 +23,7 @@ import { DefaultHttpAgent, DefaultHttpsAgent } from '../src/agent.js';
 
 // Test subjects
 import Blob from 'fetch-blob';
-import {fileFromSync} from 'fetch-blob/from.js';
+import { fileFromSync } from 'fetch-blob/from.js';
 
 import fetch, {
 	FetchError,
@@ -31,19 +31,18 @@ import fetch, {
 	Request,
 	Response
 } from '../src/index.js';
-import {FetchError as FetchErrorOrig} from '../src/errors/fetch-error.js';
-import HeadersOrig, {fromRawHeaders} from '../src/headers.js';
+import { FetchError as FetchErrorOrig } from '../src/errors/fetch-error.js';
+import HeadersOrig, { fromRawHeaders } from '../src/headers.js';
 import RequestOrig from '../src/request.js';
 import ResponseOrig from '../src/response.js';
-import Body, {getTotalBytes, extractContentType} from '../src/body.js';
+import Body, { getTotalBytes, extractContentType } from '../src/body.js';
 import TestServer from './utils/server.js';
 import chaiTimeout from './utils/chai-timeout.js';
-import { log } from 'console';
 
 const AbortControllerPolyfill = abortControllerPolyfill.AbortController;
 
 function isNodeLowerThan(version) {
-	return !~process.version.localeCompare(version, undefined, {numeric: true});
+	return !~process.version.localeCompare(version, undefined, { numeric: true });
 }
 
 const {
@@ -54,7 +53,7 @@ chai.use(chaiPromised);
 chai.use(chaiIterator);
 chai.use(chaiString);
 chai.use(chaiTimeout);
-const {expect} = chai;
+const { expect } = chai;
 
 function streamToPromise(stream, dataHandler) {
 	return new Promise((resolve, reject) => {
@@ -121,7 +120,7 @@ describe('node-fetch', () => {
 		const url = 'http://localhost:50000/';
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
-			.and.include({type: 'system', code: 'ECONNREFUSED', errno: 'ECONNREFUSED'});
+			.and.include({ type: 'system', code: 'ECONNREFUSED', errno: 'ECONNREFUSED' });
 	});
 
 	it('error should contain system error if one occurred', () => {
@@ -208,7 +207,7 @@ describe('node-fetch', () => {
 			return res.json().then(result => {
 				expect(res.bodyUsed).to.be.true;
 				expect(result).to.be.an('object');
-				expect(result).to.deep.equal({name: 'value'});
+				expect(result).to.deep.equal({ name: 'value' });
 			});
 		});
 	});
@@ -216,7 +215,7 @@ describe('node-fetch', () => {
 	it('should send request with custom headers', () => {
 		const url = `${base}inspect`;
 		const options = {
-			headers: {'x-custom-header': 'abc'}
+			headers: { 'x-custom-header': 'abc' }
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -228,7 +227,7 @@ describe('node-fetch', () => {
 	it('should accept headers instance', () => {
 		const url = `${base}inspect`;
 		const options = {
-			headers: new Headers({'x-custom-header': 'abc'})
+			headers: new Headers({ 'x-custom-header': 'abc' })
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -501,7 +500,7 @@ describe('node-fetch', () => {
 	it('should follow redirect code 301 and keep existing headers', () => {
 		const url = `${base}redirect/301`;
 		const options = {
-			headers: new Headers({'x-custom-header': 'abc'})
+			headers: new Headers({ 'x-custom-header': 'abc' })
 		};
 		return fetch(url, options).then(res => {
 			expect(res.url).to.equal(`${base}inspect`);
@@ -920,7 +919,7 @@ describe('node-fetch', () => {
 			.then(res => {
 				expect(res.status).to.equal(200);
 			})
-			.catch(() => {})
+			.catch(() => { })
 			.then(() => {
 				// Wait a few ms to see if a uncaught error occurs
 				setTimeout(() => {
@@ -983,7 +982,7 @@ describe('node-fetch', () => {
 							signal: controller.signal,
 							headers: {
 								'Content-Type': 'application/json',
-								body: JSON.stringify({hello: 'world'})
+								body: JSON.stringify({ hello: 'world' })
 							}
 						}
 					)
@@ -1004,7 +1003,7 @@ describe('node-fetch', () => {
 
 			it('should support multiple request cancellation with signal', () => {
 				const fetches = [
-					fetch(`${base}timeout`, {signal: controller.signal}),
+					fetch(`${base}timeout`, { signal: controller.signal }),
 					fetch(
 						`${base}timeout`,
 						{
@@ -1012,7 +1011,7 @@ describe('node-fetch', () => {
 							signal: controller.signal,
 							headers: {
 								'Content-Type': 'application/json',
-								body: JSON.stringify({hello: 'world'})
+								body: JSON.stringify({ hello: 'world' })
 							}
 						}
 					)
@@ -1075,7 +1074,7 @@ describe('node-fetch', () => {
 			it('should reject response body with AbortError when aborted before stream has been read completely', () => {
 				return expect(fetch(
 					`${base}slow`,
-					{signal: controller.signal}
+					{ signal: controller.signal }
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1091,7 +1090,7 @@ describe('node-fetch', () => {
 			it('should reject response body methods immediately with AbortError when aborted before stream is disturbed', () => {
 				return expect(fetch(
 					`${base}slow`,
-					{signal: controller.signal}
+					{ signal: controller.signal }
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1106,7 +1105,7 @@ describe('node-fetch', () => {
 			it('should emit error event to response body with an AbortError when aborted before underlying stream is closed', done => {
 				expect(fetch(
 					`${base}slow`,
-					{signal: controller.signal}
+					{ signal: controller.signal }
 				))
 					.to.eventually.be.fulfilled
 					.then(res => {
@@ -1121,11 +1120,11 @@ describe('node-fetch', () => {
 			});
 
 			it('should cancel request body of type Stream with AbortError when aborted', () => {
-				const body = new stream.Readable({objectMode: true});
-				body._read = () => {};
+				const body = new stream.Readable({ objectMode: true });
+				body._read = () => { };
 				const promise = fetch(
 					`${base}slow`,
-					{signal: controller.signal, body, method: 'POST'}
+					{ signal: controller.signal, body, method: 'POST' }
 				);
 
 				const result = Promise.all([
@@ -1160,13 +1159,13 @@ describe('node-fetch', () => {
 		() => {
 			it('should remove internal AbortSignal event listener after request is aborted', () => {
 				const controller = new AbortControllerPolyfill();
-				const {signal} = controller;
+				const { signal } = controller;
 
 				setTimeout(() => {
 					controller.abort();
 				}, 20);
 
-				return expect(fetch(`${base}timeout`, {signal}))
+				return expect(fetch(`${base}timeout`, { signal }))
 					.to.eventually.be.rejected
 					.and.be.an.instanceof(Error)
 					.and.have.property('name', 'AbortError')
@@ -1177,11 +1176,11 @@ describe('node-fetch', () => {
 
 			it('should remove internal AbortSignal event listener after request and response complete without aborting', () => {
 				const controller = new AbortControllerPolyfill();
-				const {signal} = controller;
-				const fetchHtml = fetch(`${base}html`, {signal})
+				const { signal } = controller;
+				const fetchHtml = fetch(`${base}html`, { signal })
 					.then(res => res.text());
-				const fetchResponseError = fetch(`${base}error/reset`, {signal});
-				const fetchRedirect = fetch(`${base}redirect/301`, {signal}).then(res => res.json());
+				const fetchResponseError = fetch(`${base}error/reset`, { signal });
+				const fetchRedirect = fetch(`${base}redirect/301`, { signal }).then(res => res.json());
 				return Promise.all([
 					expect(fetchHtml).to.eventually.be.fulfilled.and.equal('<html></html>'),
 					expect(fetchResponseError).to.be.eventually.rejected,
@@ -1201,15 +1200,15 @@ describe('node-fetch', () => {
 
 	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
 		return Promise.all([
-			expect(fetch(`${base}inspect`, {signal: {}}))
+			expect(fetch(`${base}inspect`, { signal: {} }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal'),
-			expect(fetch(`${base}inspect`, {signal: ''}))
+			expect(fetch(`${base}inspect`, { signal: '' }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal'),
-			expect(fetch(`${base}inspect`, {signal: Object.create(null)}))
+			expect(fetch(`${base}inspect`, { signal: Object.create(null) }))
 				.to.be.eventually.rejected
 				.and.be.an.instanceof(TypeError)
 				.and.have.property('message').includes('AbortSignal')
@@ -1218,10 +1217,10 @@ describe('node-fetch', () => {
 
 	it('should gracefully handle a nullish signal', () => {
 		return Promise.all([
-			fetch(`${base}hello`, {signal: null}).then(res => {
+			fetch(`${base}hello`, { signal: null }).then(res => {
 				return expect(res.ok).to.be.true;
 			}),
-			fetch(`${base}hello`, {signal: undefined}).then(res => {
+			fetch(`${base}hello`, { signal: undefined }).then(res => {
 				return expect(res.ok).to.be.true;
 			})
 		]);
@@ -1551,7 +1550,7 @@ describe('node-fetch', () => {
 		// Note that fetch simply calls tostring on an object
 		const options = {
 			method: 'POST',
-			body: {a: 1}
+			body: { a: 1 }
 		};
 		return fetch(url, options).then(res => {
 			return res.json();
@@ -1572,7 +1571,7 @@ describe('node-fetch', () => {
 
 	it('constructing a Request with URLSearchParams as body should have a Content-Type', () => {
 		const parameters = new URLSearchParams();
-		const request = new Request(base, {method: 'POST', body: parameters});
+		const request = new Request(base, { method: 'POST', body: parameters });
 		expect(request.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded;charset=UTF-8');
 	});
 
@@ -1587,7 +1586,7 @@ describe('node-fetch', () => {
 	// Body should been cloned...
 	it('constructing a Request/Response with URLSearchParams and mutating it should not affected body', () => {
 		const parameters = new URLSearchParams();
-		const request = new Request(`${base}inspect`, {method: 'POST', body: parameters});
+		const request = new Request(`${base}inspect`, { method: 'POST', body: parameters });
 		parameters.append('a', '1');
 		return request.text().then(text => {
 			expect(text).to.equal('');
@@ -1614,7 +1613,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should still recognize URLSearchParams when extended', () => {
-		class CustomSearchParameters extends URLSearchParams {}
+		class CustomSearchParameters extends URLSearchParams { }
 		const parameters = new CustomSearchParameters();
 		parameters.append('a', '1');
 
@@ -1636,7 +1635,7 @@ describe('node-fetch', () => {
 	/* For 100% code coverage, checks for duck-typing-only detection
 	 * where both constructor.name and brand tests fail */
 	it('should still recognize URLSearchParams when extended from polyfill', () => {
-		class CustomPolyfilledSearchParameters extends URLSearchParams {}
+		class CustomPolyfilledSearchParameters extends URLSearchParams { }
 		const parameters = new CustomPolyfilledSearchParameters();
 		parameters.append('a', '1');
 
@@ -1854,7 +1853,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return Promise.all([res.json(), r1.text()]).then(results => {
-				expect(results[0]).to.deep.equal({name: 'value'});
+				expect(results[0]).to.deep.equal({ name: 'value' });
 				expect(results[1]).to.equal('{"name":"value"}');
 			});
 		});
@@ -1865,7 +1864,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return res.json().then(result => {
-				expect(result).to.deep.equal({name: 'value'});
+				expect(result).to.deep.equal({ name: 'value' });
 				return r1.text().then(result => {
 					expect(result).to.equal('{"name":"value"}');
 				});
@@ -1880,7 +1879,7 @@ describe('node-fetch', () => {
 			return r1.text().then(result => {
 				expect(result).to.equal('{"name":"value"}');
 				return res.json().then(result => {
-					expect(result).to.deep.equal({name: 'value'});
+					expect(result).to.deep.equal({ name: 'value' });
 				});
 			});
 		});
@@ -1929,7 +1928,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+			fetch(url, { highWaterMark: 10 }).then(res => res.clone().buffer())
 		).to.timeout;
 	});
 
@@ -1963,7 +1962,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+			fetch(url, { highWaterMark: 10 }).then(res => res.clone().buffer())
 		).not.to.timeout;
 	});
 
@@ -1978,7 +1977,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes((2 * 512 * 1024) - 1));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 512 * 1024}).then(res => res.clone().buffer())
+			fetch(url, { highWaterMark: 512 * 1024 }).then(res => res.clone().buffer())
 		).not.to.timeout;
 	});
 
@@ -2132,7 +2131,7 @@ describe('node-fetch', () => {
 				method: 'POST',
 				body: blob
 			});
-		}).then(res => res.json()).then(({body, headers}) => {
+		}).then(res => res.json()).then(({ body, headers }) => {
 			expect(body).to.equal('world');
 			expect(headers['content-type']).to.equal(type);
 			expect(headers['content-length']).to.equal(String(length));
@@ -2200,17 +2199,17 @@ describe('node-fetch', () => {
 
 	// Issue #414
 	it('should reject if attempt to accumulate body stream throws', () => {
-		const res = new Response(stream.Readable.from((async function * () {
+		const res = new Response(stream.Readable.from((async function* () {
 			yield Buffer.from('tada');
 			await new Promise(resolve => {
 				setTimeout(resolve, 200);
 			});
-			yield {tada: 'yes'};
+			yield { tada: 'yes' };
 		})()));
 
 		return expect(res.text()).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
-			.and.include({type: 'system'})
+			.and.include({ type: 'system' })
 			.and.have.property('message').that.include('Could not create Buffer');
 	});
 
@@ -2224,8 +2223,8 @@ describe('node-fetch', () => {
 			return dns.lookup(hostname, options, callback);
 		}
 
-		const agent = http.Agent({lookup: lookupSpy});
-		return fetch(url, {agent}).then(() => {
+		const agent = http.Agent({ lookup: lookupSpy });
+		return fetch(url, { agent }).then(() => {
 			expect(called).to.equal(2);
 		});
 	});
@@ -2241,8 +2240,8 @@ describe('node-fetch', () => {
 			return dns.lookup(hostname, {}, callback);
 		}
 
-		const agent = http.Agent({lookup: lookupSpy, family});
-		return fetch(url, {agent}).then(() => {
+		const agent = http.Agent({ lookup: lookupSpy, family });
+		return fetch(url, { agent }).then(() => {
 			expect(families).to.have.length(2);
 			expect(families[0]).to.equal(family);
 			expect(families[1]).to.equal(family);
@@ -2284,7 +2283,7 @@ describe('node-fetch', () => {
 			size: 1024
 		});
 
-		const blobBody = new Blob([bodyContent], {type: 'text/plain'});
+		const blobBody = new Blob([bodyContent], { type: 'text/plain' });
 		const blobRequest = new Request(url, {
 			method: 'POST',
 			body: blobBody,
@@ -2370,45 +2369,30 @@ describe('node-fetch using IPv6', () => {
 	});
 });
 
-describe('node-fetch using happy eyeballs (rfc 8305)', () => {
+describe.only('node-fetch using happy eyeballs (rfc 8305)', () => {
 	const local = new TestServer();
-	const timeoutServer = new net.Server();
-	let url, timeoutUrl;
-	const timeoutConnections = [];
+	let url;
 
 	before(async () => {
-		timeoutServer.listen(0, 'localhost');
-		timeoutServer.on('connection', timeoutConnections.push)
-		await Promise.all([
-			once(timeoutServer, 'listening'),
-			local.start(),
-		])
+		await local.start();
 		url = new URL(`http://localhost:${local.port}/`);
-		timeoutUrl = new URL(`https://localhost:${timeoutServer.address().port}/`);
 	});
 
 
-	after(async () => {
-		timeoutServer.close();
-		for (const connection of timeoutConnections) {
-			connection.destroy();
-		}
-		return Promise.all([
-			local.stop(),
-			once(timeoutServer, 'close'),
-		])
+	after(() => {
+		return local.stop();
 	});
 
 	const getFakeAddresses = num => {
 		const result = [];
 		while (num--) {
 			result.push(
-			{
-				family: 6,
-				address: 'dead::' + num.toString(16),
-			}, {
+				{
+					family: 6,
+					address: 'dead::' + num.toString(16),
+				}, {
 				family: 4,
-				address: '192.168.54' + num,
+				address: '192.168.54.' + num,
 			})
 		}
 		return result;
@@ -2431,13 +2415,7 @@ describe('node-fetch using happy eyeballs (rfc 8305)', () => {
 		delay: 1,
 		lookup: dns.lookup,
 		...options,
-	})
-
-	const mockTimeoutAgent = options => new DefaultHttpsAgent({
-		delay: 1,
-		lookup: dns.lookup,
-		...options,
-	})
+	});
 
 	it('should succeed with incorrect addresses prepended to correct', () => {
 		return fetch(`${url.href}hello`, {
@@ -2450,12 +2428,11 @@ describe('node-fetch using happy eyeballs (rfc 8305)', () => {
 	});
 
 	it('fail with all incorrect addresses', () => {
-		return expect(fetch(`${timeoutUrl.href}hello`, {
+		return expect(fetch(`${url.href}hello`, {
+			agent: mockAgent({
 				timeout: 1,
-			agent: mockTimeoutAgent({
-				timeout: 1,
-				delay:2,
-				lookup: mockLookup(() => getFakeAddresses(5)),
+				delay: 1,
+				lookup: mockLookup(() => getFakeAddresses(20)),
 			}),
 		})).to.eventually.be.rejected
 			.and.have.property('message').that.include('timed out');
@@ -2463,12 +2440,12 @@ describe('node-fetch using happy eyeballs (rfc 8305)', () => {
 
 	it('should connect when spamming all IPs with many incorrect addresses', async () => {
 		const start = Date.now();
-		await fetch('https://google.com', {
-			timeout: 200,
-			agent: mockTimeoutAgent({
+		const resp = await fetch(`${url.href}hello`, {
+			agent: mockAgent({
 				lookup: mockLookup(real => [...getFakeAddresses(20), ...real]),
 			}),
 		})
+		expect(await resp.text()).to.equal('world');
 		if (start - Date.now() > 1000) {
 			throw new Error('Could not connect in time.')
 		}
@@ -2477,15 +2454,14 @@ describe('node-fetch using happy eyeballs (rfc 8305)', () => {
 	it('can abort requests', async () => {
 		const ac = new AbortController();
 		try {
-			const prom = fetch(url.href, {
+			ac.abort();
+			await fetch(url.href, {
 				signal: ac.signal,
 				delay: 1000,
 				agent: mockAgent({
 					lookup: mockLookup(() => getFakeAddresses(1)),
 				}),
 			});
-			ac.abort();
-			await prom;
 			throw new Error('Request was not aborted.');
 		} catch (err) {
 			expect(err.name).to.equal('AbortError');

--- a/test/main.js
+++ b/test/main.js
@@ -2342,11 +2342,11 @@ describe('node-fetch', () => {
 			result.push(
 				{
 					family: 6,
-					address: 'dead::' + num.toString(16),
+					address: '2001:db8:ffff:ffff:ffff:ffff:ffff:'	 + num.toString(16),
 				},
 				{
 					family: 4,
-					address: '123.123.123' + num,
+					address: '192.0.2.' + num,
 				},
 			)
 		}


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (provide an overview)**

Implement happy eyeballs algorithm. For full description, see https://github.com/zwhitchcox/happy-eyeballs

**Which issue (if any) does this pull request address?**

#1297

**Is there anything you'd like reviewers to know?**

The meat and potatoes of the algorithm is done here: https://github.com/zwhitchcox/happy-eyeballs/blob/master/src/happy-eyeballs.ts

### A few design notes:

#### Providing a Default User Agent

I think the cleanest way to implement the change is to provide a default agent.

That way, the existing user interface is preserved, and the user is still free to customize `fetch` requests any way they want.

This is also, the more loyal to the way the browser's `fetch` works, because happy eyeballs is implemented by the user agent, not through any other interface.

I did consider many other methods, but ultimately, I think this makes the most sense, and I think it will lead to the least confusion when debugging, as the inter-operability between various user agent methods can be complex.

This is also the most forward thinking in my opinion, because in future use cases, we will have a default user agent which can implement other desired behavior.

This also provides flexibility, all behavior is confined to on neat little package which can easily be overridden without fear of compatibility issues with other non-(NodeJS)-standard behavior.

#### Keeping Happy Eyeballs in Another NPM Package

I thought about copying the code from `happy-eyeballs` into this repository so it could have its own version of the code that it can easily change, but decided against this because

1. This isn't really a `node-fetch` specific feature, and if others want to use it outside of `node-fetch`, it creates a foundation that all other libraries can use and "speak the same language". In other words, developers won't have to fear compatibility issues with different implementations of `happy-eyeballs`, which I think provides a big benefit.
2. This will likely ultimately be a part of NodeJS (my next PR), so there's really no sense in adding all that code to this library only to remove it later. All that will need to be removed is two lines of code this way.
3. It's probably better to keep this type of thing external from `node-fetch` anyway, because it's kind of an extraneous detail, not really related to the core functionality of `node-fetch`, and I didn't want to add all that noise/bloat to the code base.

---

All that being said, I'm flexible and open to feedback/alterations that this team feels necessary, so please let me know any changes/improvements that need to be made.