### PR TITLE
fix(types): declare buffer() deprecated

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -104,6 +104,9 @@ declare class BodyMixin {
 	readonly bodyUsed: boolean;
 	readonly size: number;
 
+	/**
+ 	* @deprecated Please use 'response.arrayBuffer()' instead of 'response.buffer()
+ 	*/
 	buffer(): Promise<Buffer>;
 	arrayBuffer(): Promise<ArrayBuffer>;
 	blob(): Promise<Blob>;


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: adds a type deprecation to the already existing runtime deprecation.

**What changes did you make? (provide an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**