### PR TITLE
fix(package): Add exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "A light-weight module that brings Fetch API to node.js",
   "main": "./src/index.js",
+  "exports": "./src/index.js",
   "sideEffects": false,
   "type": "module",
   "files": [


### PR DESCRIPTION
<!--
Please read and follow these instructions before creating and submitting a pull request:

- If you're fixing a bug, ensure you add unit tests to prove that it works.
- Before adding a feature, it is best to create an issue explaining it first. It would save you some effort in case we don't consider it should be included in node-fetch.
- If you are reporting a bug, adding failing units tests can be a good idea.
-->

**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: 

adds an `exports` field to `package.json` which limits the accessibility to `index.js` only.

**What changes did you make? (provide an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to know?**
