### PR TITLE
fix(URL): prefer built in URL version when available and fallback to whatwg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-fetch",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "description": "A light-weight module that brings window.fetch to node.js",
     "main": "lib/index.js",
     "browser": "./browser.js",

--- a/src/request.js
+++ b/src/request.js
@@ -14,7 +14,7 @@ import Headers, { exportNodeCompatibleHeaders } from './headers.js';
 import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const INTERNALS = Symbol('Request internals');
-const URL = whatwgUrl.URL;
+const URL = Url.URL || whatwgUrl.URL;
 
 // fix an issue where "format", "parse" aren't a named export for node <10
 const parse_url = Url.parse;

--- a/test/test.js
+++ b/test/test.js
@@ -2875,4 +2875,11 @@ describe('issue #1290', function() {
 			});
 		});
 	});
+
+	// #1342
+	it('should not throw with a valid URL', () => {
+		const url = 'https://r2---sn-n4v7sney.example.com';
+		new Request(url);
+	});
+
 });


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Bug fix

**What changes did you make? (provide an overview)**

Use the newest URL instance whenever it's available.

**Which issue (if any) does this pull request address?**

- fix #1342 (but only for node v6.13.0 and above)