### PR TITLE
fix(Request): Fix logical operator priority to disallow GET/HEAD with non-empty body

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -60,7 +60,7 @@ export default class Request extends Body {
 		method = method.toUpperCase();
 
 		// eslint-disable-next-line no-eq-null, eqeqeq
-		if (((init.body != null || isRequest(input)) && input.body !== null) &&
+		if ((init.body != null || (isRequest(input) && input.body !== null)) &&
 			(method === 'GET' || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}

--- a/test/request.js
+++ b/test/request.js
@@ -123,6 +123,8 @@ describe('Request', () => {
 			.to.throw(TypeError);
 		expect(() => new Request(base, {body: 'a', method: 'head'}))
 			.to.throw(TypeError);
+		expect(() => new Request(new Request(base), {body: 'a'}))
+			.to.throw(TypeError);
 	});
 
 	it('should throw error when including credentials', () => {


### PR DESCRIPTION
## Purpose

There was a regression introduced in a conditional which checks for a `body` override in `Request`, where brackets were at the wrong place. Because of this, in certain cases, one could create a GET/HEAD `Request` instance with a non-empty body, which should normally result in an `TypeError` thrown.

## Changes

This PR fixes the issue, and adds a test for this particular case.

## Additional information


___

- [x] I added unit test(s)

___
