### PR TITLE
fix: handle errors from the request body stream

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes will be recorded here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* fix: handle errors from the request body stream by @mdmitry01 in https://github.com/node-fetch/node-fetch/pull/1392
+
 ## 3.1.0
 
 ## What's Changed

--- a/src/body.js
+++ b/src/body.js
@@ -6,7 +6,7 @@
  */
 
 import Stream, {PassThrough} from 'node:stream';
-import {types, deprecate} from 'node:util';
+import {types, deprecate, promisify} from 'node:util';
 
 import Blob from 'fetch-blob';
 import {FormData, formDataToBlob} from 'formdata-polyfill/esm.min.js';
@@ -15,6 +15,7 @@ import {FetchError} from './errors/fetch-error.js';
 import {FetchBaseError} from './errors/base.js';
 import {isBlob, isURLSearchParameters} from './utils/is.js';
 
+const pipeline = promisify(Stream.pipeline);
 const INTERNALS = Symbol('Body internals');
 
 /**
@@ -379,14 +380,14 @@ export const getTotalBytes = request => {
  *
  * @param {Stream.Writable} dest The stream to write to.
  * @param obj.body Body object from the Body instance.
- * @returns {void}
+ * @returns {Promise<void>}
  */
-export const writeToStream = (dest, {body}) => {
+export const writeToStream = async (dest, {body}) => {
 	if (body === null) {
 		// Body is null
 		dest.end();
 	} else {
 		// Body is stream
-		body.pipe(dest);
+		await pipeline(body, dest);
 	}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -291,7 +291,7 @@ export default async function fetch(url, options_) {
 			resolve(response);
 		});
 
-		// eslint-disable-next-line prefer-await-to-then
+		// eslint-disable-next-line promise/prefer-await-to-then
 		writeToStream(request_, request).catch(reject);
 	});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -291,6 +291,7 @@ export default async function fetch(url, options_) {
 			resolve(response);
 		});
 
+		// eslint-disable-next-line prefer-await-to-then
 		writeToStream(request_, request).catch(reject);
 	});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -291,7 +291,7 @@ export default async function fetch(url, options_) {
 			resolve(response);
 		});
 
-		writeToStream(request_, request);
+		writeToStream(request_, request).catch(reject);
 	});
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -1463,7 +1463,7 @@ describe('node-fetch', () => {
 			method: 'POST',
 			body: requestBody
 		};
-		const errorMessage = 'request body stream error'
+		const errorMessage = 'request body stream error';
 		setImmediate(() => {
 			requestBody.emit('error', new Error(errorMessage));
 		});

--- a/test/main.js
+++ b/test/main.js
@@ -1456,6 +1456,21 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should reject if the request body stream emits an error', () => {
+		const url = `${base}inspect`;
+		const requestBody = new stream.PassThrough();
+		const options = {
+			method: 'POST',
+			body: requestBody
+		};
+		const errorMessage = 'request body stream error'
+		setImmediate(() => {
+			requestBody.emit('error', new Error(errorMessage));
+		});
+		return expect(fetch(url, options))
+			.to.be.rejectedWith(Error, errorMessage);
+	});
+
 	it('should allow POST request with form-data as body', () => {
 		const form = new FormData();
 		form.append('a', '1');


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
`node-fetch` does not handle errors from the request body stream correctly. This PR fixes it.

## Changes
[`body.pipe(dest)`](https://github.com/node-fetch/node-fetch/blob/0284826de6e733c717447c6dfcddc5f0b538b254/src/body.js#L390) has been replaced with the `pipeline` function from the `stream` module.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [x] I added unit test(s)