### PR TITLE
fix: Add catch/reject for invalid redirect URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,10 +128,18 @@ export default async function fetch(url, options_) {
 			if (isRedirect(response_.statusCode)) {
 				// HTTP fetch step 5.2
 				const location = headers.get('Location');
-
+				
 				// HTTP fetch step 5.3
-				const locationURL = location === null ? null : new URL(location, request.url);
-
+				let locationURL;
+				
+				try{
+					locationURL = location === null ? null : new URL(location, request.url);
+				} catch {
+					reject(new FetchError(`invalid redirect url: ${location} from: ${request.url}`, 'invalid-redirect'));
+					finalize();
+					return;
+				}
+			
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

HTTP responses with invalid URLs in the location header field resulted in an uncatchable exception (`TypeError [ERR_INVALID_URL]: Invalid URL`), even in "manual" redirect-handling mode.

This patch fixes the issue, invalid redirect targets are now rejected gracefully.


## Changes

- Add missing try/catch block around `new URL(…)` in `request_.on('response', …)` of src/index.js
- Introduce new FetchError type "invalid-redirect"

## Additional information

Real-world example to reproduce the problem: `Location: http://`

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I updated ./docs/v3-UPGRADE-GUIDE
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #889
- Fixes #1386

