### PR TITLE
core: Don't use buffer to make a blob

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -131,7 +131,7 @@ export default class Body {
 	 */
 	async blob() {
 		const ct = (this.headers && this.headers.get('content-type')) || (this[INTERNALS].body && this[INTERNALS].body.type) || '';
-		const buf = await this.buffer();
+		const buf = await this.arrayBuffer();
 
 		return new Blob([buf], {
 			type: ct


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
It was logging a warning for using deprecated `body.buffer()` implicit when calling `body.blob()`

## Changes
construct blob using a arrayBuffer instead

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fix #1401
