### PR TITLE
chore: use Symbol.toStringTag in isAbortSignal check

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -15,6 +15,7 @@ import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const INTERNALS = Symbol('Request internals');
 const URL = Url.URL || whatwgUrl.URL;
+const NAME = Symbol.toStringTag;
 
 // fix an issue where "format", "parse" aren't a named export for node <10
 const parse_url = Url.parse;
@@ -56,13 +57,23 @@ function isRequest(input) {
 	);
 }
 
-function isAbortSignal(signal) {
+/**
+ * Check if `obj` is an instance of AbortSignal.
+ * @param {*} object - Object to check for
+ * @return {boolean}
+ */
+function isAbortSignal(object) {
 	const proto = (
-		signal
-		&& typeof signal === 'object'
-		&& Object.getPrototypeOf(signal)
+		object
+		&& typeof object === 'object'
+		&& Object.getPrototypeOf(object)
 	);
-	return !!(proto && proto.constructor.name === 'AbortSignal');
+	return !!(proto && proto.constructor.name === 'AbortSignal') || (
+		typeof object === 'object' && (
+			object[NAME] === 'AbortSignal' ||
+			object[NAME] === 'EventTarget'
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
2.x.x version `isAbortSignal` is not always working correctly with code processed by webpack, and for implementations  [with a constructors custom name](https://github.com/node-fetch/node-fetch/issues/751).  This minor change should be useful for people who cannot migrate to 3.x.x version right now.

## Changes
This PR basically extends `isAbortSignal` with the same function's code from 3-rd version of the project.

## Additional information
I tried to cover it with tests, but I failed :( 

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I added unit test(s)

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #751

___

Authors, maintainers, and contributors of the project, thank you. You are awesome ❤️