### PR TITLE
core: Don't use global buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "formdata-node": "^4.2.4",
     "mocha": "^9.1.3",
     "p-timeout": "^5.0.0",
-    "stream-consumers": "^1.0.0",
+    "stream-consumers": "^1.0.1",
     "tsd": "^0.14.0",
     "xo": "^0.39.1"
   },

--- a/package.json
+++ b/package.json
@@ -58,13 +58,14 @@
     "formdata-node": "^4.2.4",
     "mocha": "^9.1.3",
     "p-timeout": "^5.0.0",
+    "stream-consumers": "^1.0.0",
     "tsd": "^0.14.0",
     "xo": "^0.39.1"
   },
   "dependencies": {
     "data-uri-to-buffer": "^4.0.0",
-    "formdata-polyfill": "^4.0.10",
-    "fetch-blob": "^3.1.3"
+    "fetch-blob": "^3.1.3",
+    "formdata-polyfill": "^4.0.10"
   },
   "tsd": {
     "cwd": "@types",

--- a/src/body.js
+++ b/src/body.js
@@ -7,6 +7,7 @@
 
 import Stream, {PassThrough} from 'node:stream';
 import {types, deprecate, promisify} from 'node:util';
+import {Buffer} from 'node:buffer';
 
 import Blob from 'fetch-blob';
 import {FormData, formDataToBlob} from 'formdata-polyfill/esm.min.js';

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ import http from 'node:http';
 import https from 'node:https';
 import zlib from 'node:zlib';
 import Stream, {PassThrough, pipeline as pump} from 'node:stream';
+import {Buffer} from 'node:buffer';
+
 import dataUriToBuffer from 'data-uri-to-buffer';
 
 import {writeToStream, clone} from './body.js';

--- a/test/external-encoding.js
+++ b/test/external-encoding.js
@@ -5,15 +5,14 @@ const {expect} = chai;
 
 describe('external encoding', () => {
 	describe('data uri', () => {
-		it('should accept base64-encoded gif data uri', () => {
-			return fetch('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=').then(r => {
-				expect(r.status).to.equal(200);
-				expect(r.headers.get('Content-Type')).to.equal('image/gif');
-
-				return r.buffer().then(b => {
-					expect(b).to.be.an.instanceOf(Buffer);
-				});
-			});
+		it('should accept base64-encoded gif data uri', async () => {
+			const b64 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='
+			const res = await fetch(b64);
+			expect(res.status).to.equal(200);
+			expect(res.headers.get('Content-Type')).to.equal('image/gif');
+			const buf = await res.arrayBuffer();
+			expect(buf.byteLength).to.equal(35);
+			expect(buf).to.be.an.instanceOf(ArrayBuffer);
 		});
 
 		it('should accept data uri with specified charset', async () => {

--- a/test/external-encoding.js
+++ b/test/external-encoding.js
@@ -6,7 +6,7 @@ const {expect} = chai;
 describe('external encoding', () => {
 	describe('data uri', () => {
 		it('should accept base64-encoded gif data uri', async () => {
-			const b64 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='
+			const b64 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
 			const res = await fetch(b64);
 			expect(res.status).to.equal(200);
 			expect(res.headers.get('Content-Type')).to.equal('image/gif');

--- a/test/headers.js
+++ b/test/headers.js
@@ -178,7 +178,6 @@ describe('Headers', () => {
 		res.j = Number.NaN;
 		res.k = true;
 		res.l = false;
-		res.m = Buffer.from('test');
 
 		const h1 = new Headers(res);
 		h1.set('n', [1, 2]);
@@ -198,7 +197,6 @@ describe('Headers', () => {
 		expect(h1Raw.j).to.include('NaN');
 		expect(h1Raw.k).to.include('true');
 		expect(h1Raw.l).to.include('false');
-		expect(h1Raw.m).to.include('test');
 		expect(h1Raw.n).to.include('1,2');
 		expect(h1Raw.n).to.include('3,4');
 

--- a/test/main.js
+++ b/test/main.js
@@ -1817,7 +1817,7 @@ describe('node-fetch', () => {
 
 	it('should allow piping response body as stream', async () => {
 		const url = `${base}hello`;
-		const res = await fetch(url)
+		const res = await fetch(url);
 		expect(res.body).to.be.an.instanceof(stream.Transform);
 		const body = await text(res.body);
 		expect(body).to.equal('world');
@@ -1825,7 +1825,7 @@ describe('node-fetch', () => {
 
 	it('should allow cloning a response, and use both as stream', async () => {
 		const url = `${base}hello`;
-		const res = await fetch(url)
+		const res = await fetch(url);
 		const r1 = res.clone();
 		expect(res.body).to.be.an.instanceof(stream.Transform);
 		expect(r1.body).to.be.an.instanceof(stream.Transform);

--- a/test/main.js
+++ b/test/main.js
@@ -1314,23 +1314,6 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should allow POST request with buffer body', () => {
-		const url = `${base}inspect`;
-		const options = {
-			method: 'POST',
-			body: Buffer.from('a=1', 'utf-8')
-		};
-		return fetch(url, options).then(res => {
-			return res.json();
-		}).then(res => {
-			expect(res.method).to.equal('POST');
-			expect(res.body).to.equal('a=1');
-			expect(res.headers['transfer-encoding']).to.be.undefined;
-			expect(res.headers['content-type']).to.be.undefined;
-			expect(res.headers['content-length']).to.equal('3');
-		});
-	});
-
 	it('should allow POST request with ArrayBuffer body', () => {
 		const encoder = new TextEncoder();
 		const url = `${base}inspect`;

--- a/test/main.js
+++ b/test/main.js
@@ -36,6 +36,7 @@ import TestServer from './utils/server.js';
 import chaiTimeout from './utils/chai-timeout.js';
 
 const AbortControllerPolyfill = abortControllerPolyfill.AbortController;
+const encoder = new TextEncoder();
 
 function isNodeLowerThan(version) {
 	return !~process.version.localeCompare(version, undefined, {numeric: true});
@@ -1315,7 +1316,6 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBuffer body', () => {
-		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
@@ -1334,7 +1334,7 @@ describe('node-fetch', () => {
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: new VMUint8Array(Buffer.from('Hello, world!\n')).buffer
+			body: new VMUint8Array(encoder.encode('Hello, world!\n')).buffer
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
@@ -1346,7 +1346,6 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (Uint8Array) body', () => {
-		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
@@ -1362,7 +1361,6 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (DataView) body', () => {
-		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
@@ -1381,7 +1379,7 @@ describe('node-fetch', () => {
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
-			body: new VMUint8Array(Buffer.from('Hello, world!\n'))
+			body: new VMUint8Array(encoder.encode('Hello, world!\n'))
 		};
 		return fetch(url, options).then(res => res.json()).then(res => {
 			expect(res.method).to.equal('POST');
@@ -1393,7 +1391,6 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with ArrayBufferView (Uint8Array, offset, length) body', () => {
-		const encoder = new TextEncoder();
 		const url = `${base}inspect`;
 		const options = {
 			method: 'POST',
@@ -2216,7 +2213,7 @@ describe('node-fetch', () => {
 	// Issue #414
 	it('should reject if attempt to accumulate body stream throws', () => {
 		const res = new Response(stream.Readable.from((async function * () {
-			yield Buffer.from('tada');
+			yield encoder.encode('tada');
 			await new Promise(resolve => {
 				setTimeout(resolve, 200);
 			});
@@ -2312,7 +2309,7 @@ describe('node-fetch', () => {
 			size: 1024
 		});
 
-		const bufferBody = Buffer.from(bodyContent);
+		const bufferBody = encoder.encode(bodyContent);
 		const bufferRequest = new Request(url, {
 			method: 'POST',
 			body: bufferBody,

--- a/test/referrer.js
+++ b/test/referrer.js
@@ -127,7 +127,7 @@ describe('Request constructor', () => {
 			expect(() => {
 				const req = new Request('http://example.com', {referrer: 'foobar'});
 				expect.fail(req);
-			}).to.throw(TypeError, 'Invalid URL: foobar');
+			}).to.throw(TypeError, /Invalid URL/);
 		});
 	});
 

--- a/test/request.js
+++ b/test/request.js
@@ -208,7 +208,7 @@ describe('Request', () => {
 			body: new TextEncoder().encode('a=1')
 		});
 		expect(request.url).to.equal(url);
-		const blob = await request.blob()
+		const blob = await request.blob();
 		expect(blob).to.be.an.instanceOf(Blob);
 		expect(blob.size).to.equal(3);
 		expect(blob.type).to.equal('');

--- a/test/request.js
+++ b/test/request.js
@@ -205,7 +205,7 @@ describe('Request', () => {
 		const url = base;
 		const request = new Request(url, {
 			method: 'POST',
-			body: 'a=1'
+			body: new TextEncoder().encode('a=1')
 		});
 		expect(request.url).to.equal(url);
 		const blob = await request.blob()

--- a/test/request.js
+++ b/test/request.js
@@ -201,18 +201,17 @@ describe('Request', () => {
 		});
 	});
 
-	it('should support blob() method', () => {
+	it('should support blob() method', async () => {
 		const url = base;
 		const request = new Request(url, {
 			method: 'POST',
-			body: Buffer.from('a=1')
+			body: 'a=1'
 		});
 		expect(request.url).to.equal(url);
-		return request.blob().then(result => {
-			expect(result).to.be.an.instanceOf(Blob);
-			expect(result.size).to.equal(3);
-			expect(result.type).to.equal('');
-		});
+		const blob = await request.blob()
+		expect(blob).to.be.an.instanceOf(Blob);
+		expect(blob.size).to.equal(3);
+		expect(blob.type).to.equal('');
 	});
 
 	it('should support clone() method', () => {

--- a/test/response.js
+++ b/test/response.js
@@ -154,13 +154,6 @@ describe('Response', () => {
 		});
 	});
 
-	it('should support buffer as body', () => {
-		const res = new Response(Buffer.from('a=1'));
-		return res.text().then(result => {
-			expect(result).to.equal('a=1');
-		});
-	});
-
 	it('should support ArrayBuffer as body', () => {
 		const encoder = new TextEncoder();
 		const res = new Response(encoder.encode('a=1'));

--- a/test/utils/read-stream.js
+++ b/test/utils/read-stream.js
@@ -1,9 +1,0 @@
-export default async function readStream(stream) {
-	const chunks = [];
-
-	for await (const chunk of stream) {
-		chunks.push(chunk instanceof Buffer ? chunk : Buffer.from(chunk));
-	}
-
-	return Buffer.concat(chunks);
-}


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Attempt to deal with one of `xo`'s  new lint rule that global Buffer shouldn't be used
and prevents us from merging the new breaking version

## Changes
- Some tests where changed to use TextEncoder instad of `Buffer.from`
- A base64 test was replaced to use `res.arrayBuffer()` instead of the deprecated  `res.buffer()`
- Two test where we test that Buffer is allowed as a body was removed... A buffer is just a instances of a Uint8Array and should be covered by this
- Other files that still use `Buffer` now imports it

## Additional information
xo that fails: https://github.com/node-fetch/node-fetch/runs/4349372595?check_suite_focus=true

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated some unit test(s)

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix part of xo new breaking release
