### PR TITLE
typing fix for typescript ~= 4.4

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -104,12 +104,12 @@ export type BodyInit =
 	| Buffer
 	| URLSearchParams
 	| FormData
-	| NodeJS.ReadableStream
+	| ReadableStream<Uint8Array>
 	| string;
 declare class BodyMixin {
 	constructor(body?: BodyInit, options?: {size?: number});
 
-	readonly body: NodeJS.ReadableStream | null;
+	readonly body: ReadableStream<Uint8Array> | null;
 	readonly bodyUsed: boolean;
 	readonly size: number;
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Fixes an issue where `Response` could not be properly cast from `node-fetch` flavor `Response` to typescript's native `Response` type.

## Changes

Use `ReadableStream<Uint8Array>` instead of `NodeJS.ReadableStream`

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I updated ./docs/v3-UPGRADE-GUIDE
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #000
