### PR TITLE
fix(Headers): don't forward secure headers to 3th party

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import Request, {getNodeRequestOptions} from './request.js';
 import {FetchError} from './errors/fetch-error.js';
 import {AbortError} from './errors/abort-error.js';
 import {isRedirect} from './utils/is-redirect.js';
+import {isDomainOrSubdomain} from './utils/is.js';
 import {parseReferrerPolicyFromHeader} from './utils/referrer.js';
 
 export {Headers, Request, Response, FetchError, AbortError, isRedirect};
@@ -187,6 +188,18 @@ export default async function fetch(url, options_) {
 							referrer: request.referrer,
 							referrerPolicy: request.referrerPolicy
 						};
+
+						// when forwarding sensitive headers like "Authorization",
+						// "WWW-Authenticate", and "Cookie" to untrusted targets.
+						// These headers will be ignored when following a redirect to a domain
+						// that is not a subdomain match or exact match of the initial domain.
+						// For example, a redirect from "foo.com" to either "foo.com" or "sub.foo.com"
+						// will forward the sensitive headers, but a redirect to "bar.com" will not.
+						if (!isDomainOrSubdomain(request.url, locationURL)) {
+							for (const name of ['authorization', 'www-authenticate', 'cookie', 'cookie2']) {
+								requestOptions.headers.delete(name);
+							}
+						}
 
 						// HTTP-redirect fetch step 9
 						if (response_.statusCode !== 303 && request.body && options_.body instanceof Stream.Readable) {

--- a/src/index.js
+++ b/src/index.js
@@ -190,8 +190,8 @@ export default async function fetch(url, options_) {
 						};
 
 						// when forwarding sensitive headers like "Authorization",
-						// "WWW-Authenticate", and "Cookie" to untrusted targets.
-						// These headers will be ignored when following a redirect to a domain
+						// "WWW-Authenticate", and "Cookie" to untrusted targets,
+						// headers will be ignored when following a redirect to a domain
 						// that is not a subdomain match or exact match of the initial domain.
 						// For example, a redirect from "foo.com" to either "foo.com" or "sub.foo.com"
 						// will forward the sensitive headers, but a redirect to "bar.com" will not.

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -56,3 +56,29 @@ export const isAbortSignal = object => {
 		)
 	);
 };
+
+/**
+ * isDomainOrSubdomain reports whether sub is a subdomain (or exact match) of
+ * the parent domain.
+ *
+ * Both domains must already be in canonical form.
+ * @param {string|URL} sub
+ * @param {string|URL} parent
+ */
+export const isDomainOrSubdomain = (sub, parent) => {
+	const a = new URL(sub).hostname;
+	const b = new URL(parent).hostname;
+
+	if (a === b) {
+		return true;
+	}
+
+	// If sub is "foo.example.com" and parent is "example.com",
+	// that means sub must end in "."+parent.
+	// Do it without allocating.
+	if (!a.endsWith(b)) {
+		return false;
+	}
+
+	return a[a.length - b.length - 1] === '.';
+};

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -62,23 +62,14 @@ export const isAbortSignal = object => {
  * the parent domain.
  *
  * Both domains must already be in canonical form.
- * @param {string|URL} sub
- * @param {string|URL} parent
+ * @param {string|URL} original
+ * @param {string|URL} destination
  */
-export const isDomainOrSubdomain = (sub, parent) => {
-	const a = new URL(sub).hostname;
-	const b = new URL(parent).hostname;
+export const isDomainOrSubdomain = (destination, original) => {
+	const orig = new URL(original).hostname;
+	const dest = new URL(destination).hostname;
 
-	if (a === b) {
-		return true;
-	}
-
-	// If sub is "foo.example.com" and parent is "example.com",
-	// that means sub must end in "."+parent.
-	// Do it without allocating.
-	if (!a.endsWith(b)) {
-		return false;
-	}
-
-	return a[a.length - b.length - 1] === '.';
+	return orig === dest || (
+		orig[orig.length - dest.length - 1] === '.' && orig.endsWith(dest)
+	);
 };

--- a/test/main.js
+++ b/test/main.js
@@ -35,6 +35,7 @@ import ResponseOrig from '../src/response.js';
 import Body, {getTotalBytes, extractContentType} from '../src/body.js';
 import TestServer from './utils/server.js';
 import chaiTimeout from './utils/chai-timeout.js';
+import {isDomainOrSubdomain} from '../src/utils/is.js';
 
 const AbortControllerPolyfill = abortControllerPolyfill.AbortController;
 const encoder = new TextEncoder();
@@ -541,6 +542,19 @@ describe('node-fetch', () => {
 		expect(headers.get('cookie2')).to.equal('is=cookie2');
 		expect(headers.get('www-authenticate')).to.equal('is=www-authenticate');
 		expect(headers.get('authorization')).to.equal('is=authorization');
+	});
+
+	it('isDomainOrSubdomain', () => {
+		// Forwarding headers to same (sub)domain are OK
+		expect(isDomainOrSubdomain('http://a.com', 'http://a.com')).to.be.true;
+		expect(isDomainOrSubdomain('http://a.com', 'http://www.a.com')).to.be.true;
+		expect(isDomainOrSubdomain('http://a.com', 'http://foo.bar.a.com')).to.be.true;
+
+		// Forwarding headers to parent domain, another sibling or a totally other domain is not ok
+		expect(isDomainOrSubdomain('http://b.com', 'http://a.com')).to.be.false;
+		expect(isDomainOrSubdomain('http://www.a.com', 'http://a.com')).to.be.false;
+		expect(isDomainOrSubdomain('http://bob.uk.com', 'http://uk.com')).to.be.false;
+		expect(isDomainOrSubdomain('http://bob.uk.com', 'http://xyz.uk.com')).to.be.false;
 	});
 
 	it('should treat broken redirect as ordinary response (follow)', () => {

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -245,6 +245,12 @@ export default class TestServer {
 			res.end();
 		}
 
+		if (p.startsWith('/redirect-to/3')) {
+			res.statusCode = p.slice(13, 16);
+			res.setHeader('Location', p.slice(17));
+			res.end();
+		}
+
 		if (p === '/redirect/302') {
 			res.statusCode = 302;
 			res.setHeader('Location', '/inspect');


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Avoid forwarding secure headers such as authorization, www-authenticate, cookie & cookie2 when redirecting to a untrusted site. (so it follows browses origin policy) 
(matches Go [behavior](https://github.com/golang/go/blob/24239120bfbff9ebee8e8c344d9d3a8ce460b686/src/net/http/client.go#L1014))

## Changes
When the location headers redirects to an other hostname, strip away secure request headers meant for the original destination

## Additional
Should patch v2 also (not many can update to esm)
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I updated ./docs/v3-UPGRADE-GUIDE
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- Fixes #1443 
