### PR TITLE
test: Update major busboy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.7.1",
-    "busboy": "^0.3.1",
+    "busboy": "^1.4.0",
     "c8": "^7.7.2",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -461,14 +461,14 @@ export default class TestServer {
 			let body = '';
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');
-			const bb = busboy({ headers: request.headers });
-    	bb.on('file', async (fieldName, file, info) => {
+			const bb = busboy({headers: request.headers});
+			bb.on('file', async (fieldName, file, info) => {
 				body += `${fieldName}=${info.filename}`;
 				// consume file data
 				// eslint-disable-next-line no-empty, no-unused-vars
 				for await (const c of file) {}
 			});
-			bb.on('field', (fieldName, value, info) => {
+			bb.on('field', (fieldName, value) => {
 				body += `${fieldName}=${value}`;
 			});
 			bb.on('close', () => {

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import zlib from 'node:zlib';
 import {once} from 'node:events';
-import Busboy from 'busboy';
+import busboy from 'busboy';
 
 export default class TestServer {
 	constructor(hostname) {
@@ -458,21 +458,20 @@ export default class TestServer {
 		}
 
 		if (p === '/multipart') {
+			let body = '';
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');
-			const busboy = new Busboy({headers: request.headers});
-			let body = '';
-			busboy.on('file', async (fieldName, file, fileName) => {
-				body += `${fieldName}=${fileName}`;
+			const bb = busboy({ headers: request.headers });
+    	bb.on('file', async (fieldName, file, info) => {
+				body += `${fieldName}=${info.filename}`;
 				// consume file data
 				// eslint-disable-next-line no-empty, no-unused-vars
 				for await (const c of file) {}
 			});
-
-			busboy.on('field', (fieldName, value) => {
+			bb.on('field', (fieldName, value, info) => {
 				body += `${fieldName}=${value}`;
 			});
-			busboy.on('finish', () => {
+			bb.on('close', () => {
 				res.end(JSON.stringify({
 					method: request.method,
 					url: request.url,
@@ -480,7 +479,7 @@ export default class TestServer {
 					body
 				}));
 			});
-			request.pipe(busboy);
+			request.pipe(bb);
 		}
 
 		if (p === '/m%C3%B6bius') {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
dependabot wasn't able to update busboy cuz it had breaking changes...

## Changes
Only affect the test server...

## Additional information
I was thinking maybe we don't really need the busboy...? we could just simply echo everything back and utilize node-fetch new `body.formData()` parsers.
and then do something like:
```js
fetch('/multipart', { method: 'post', body: formData })
  .then(res => res.formData())
  .then(formData => {
    // expect responded formData to match the posted formData
  })
```
Dos removing the dependency on busboy... 
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] Decide if we want to keep busboy as a dependency...  if not: 
  - [ ] use `res.formData()` to decode it.

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- closes #1437
