### PR TITLE
feat: export Blob, File and FormData + utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^4.0.0",
-    "fetch-blob": "^3.1.3",
+    "fetch-blob": "^3.1.4",
     "formdata-polyfill": "^4.0.10"
   },
   "tsd": {

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,12 @@ import Request, {getNodeRequestOptions} from './request.js';
 import {FetchError} from './errors/fetch-error.js';
 import {AbortError} from './errors/abort-error.js';
 import {isRedirect} from './utils/is-redirect.js';
+import {FormData} from 'formdata-polyfill/esm.min.js';
 import {isDomainOrSubdomain} from './utils/is.js';
 import {parseReferrerPolicyFromHeader} from './utils/referrer.js';
 
-export {Headers, Request, Response, FetchError, AbortError, isRedirect};
+export {FormData, Headers, Request, Response, FetchError, AbortError, isRedirect};
+export * from 'fetch-blob/from.js';
 
 const supportedSchemas = new Set(['data:', 'http:', 'https:']);
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,17 @@ import {isRedirect} from './utils/is-redirect.js';
 import {FormData} from 'formdata-polyfill/esm.min.js';
 import {isDomainOrSubdomain} from './utils/is.js';
 import {parseReferrerPolicyFromHeader} from './utils/referrer.js';
+import {
+	Blob,
+	File,
+	fileFromSync,
+	fileFrom,
+	blobFromSync,
+	blobFrom
+} from 'fetch-blob/from.js';
 
 export {FormData, Headers, Request, Response, FetchError, AbortError, isRedirect};
-export * from 'fetch-blob/from.js';
+export {Blob, File, fileFromSync, fileFrom, blobFromSync, blobFrom}
 
 const supportedSchemas = new Set(['data:', 'http:', 'https:']);
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ import {
 } from 'fetch-blob/from.js';
 
 export {FormData, Headers, Request, Response, FetchError, AbortError, isRedirect};
-export {Blob, File, fileFromSync, fileFrom, blobFromSync, blobFrom}
+export {Blob, File, fileFromSync, fileFrom, blobFromSync, blobFrom};
 
 const supportedSchemas = new Set(['data:', 'http:', 'https:']);
 

--- a/test/form-data.js
+++ b/test/form-data.js
@@ -1,8 +1,6 @@
 import {FormData as FormDataNode} from 'formdata-node';
-import {FormData} from 'formdata-polyfill/esm.min.js';
-import {Blob} from 'fetch-blob/from.js';
 import chai from 'chai';
-import {Request, Response} from '../src/index.js';
+import {Request, Response, FormData, Blob} from '../src/index.js';
 
 const {expect} = chai;
 

--- a/test/main.js
+++ b/test/main.js
@@ -12,17 +12,15 @@ import chaiPromised from 'chai-as-promised';
 import chaiIterator from 'chai-iterator';
 import chaiString from 'chai-string';
 import FormData from 'form-data';
-import {FormData as FormDataNode} from 'formdata-polyfill/esm.min.js';
 import AbortControllerMysticatea from 'abort-controller';
 import abortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
 import {text} from 'stream-consumers';
 
-// Test subjects
-import Blob from 'fetch-blob';
-import {fileFromSync} from 'fetch-blob/from.js';
-
 import fetch, {
+	Blob,
+	fileFromSync,
 	FetchError,
+	FormData as FormDataNode,
 	Headers,
 	Request,
 	Response

--- a/test/main.js
+++ b/test/main.js
@@ -1,25 +1,26 @@
 // Test tools
-import zlib from 'node:zlib';
-import crypto from 'node:crypto';
-import http from 'node:http';
-import fs from 'node:fs';
-import stream from 'node:stream';
-import path from 'node:path';
 import {lookup} from 'node:dns';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import stream from 'node:stream';
 import vm from 'node:vm';
-import chai from 'chai';
-import chaiPromised from 'chai-as-promised';
-import chaiIterator from 'chai-iterator';
-import chaiString from 'chai-string';
-import FormData from 'form-data';
+import zlib from 'node:zlib';
+
+import {text} from 'stream-consumers';
 import AbortControllerMysticatea from 'abort-controller';
 import abortControllerPolyfill from 'abortcontroller-polyfill/dist/abortcontroller.js';
-import {text} from 'stream-consumers';
+import chai from 'chai';
+import chaiIterator from 'chai-iterator';
+import chaiPromised from 'chai-as-promised';
+import chaiString from 'chai-string';
+import FormData from 'form-data';
 
 import fetch, {
 	Blob,
-	fileFromSync,
 	FetchError,
+	fileFromSync,
 	FormData as FormDataNode,
 	Headers,
 	Request,

--- a/test/response.js
+++ b/test/response.js
@@ -1,7 +1,6 @@
 import * as stream from 'node:stream';
 import chai from 'chai';
-import Blob from 'fetch-blob';
-import {Response} from '../src/index.js';
+import {Response, Blob} from '../src/index.js';
 import TestServer from './utils/server.js';
 
 const {expect} = chai;


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Making it easier to import and use `FormData, Blob & File`. Installing same dependency as `node-fetch` or otherwise getting them in a round-about way was hacky.

## Changes
This re-export the stuff so it is available to use

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit tests (for FormData, Blob, and fileFrom only) 

___

<!-- Add `- Fixes #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1454 
