### PR TITLE
fix: Use `keep-alive` by default for `Connection` header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ If no values are set, the following request headers will be sent automatically:
 | ------------------- | ------------------------------------------------------ |
 | `Accept-Encoding`   | `gzip,deflate,br` _(when `options.compress === true`)_ |
 | `Accept`            | `*/*`                                                  |
-| `Connection`        | `close` _(when no `options.agent` is present)_         |
+| `Connection`        | `keep-alive` _(when no `options.agent` is present)_         |
 | `Content-Length`    | _(automatically calculated, if possible)_              |
 | `Host`              | _(host and port information from the target URI)_      |
 | `Transfer-Encoding` | `chunked` _(when `req.body` is a stream)_              |

--- a/src/request.js
+++ b/src/request.js
@@ -287,7 +287,7 @@ export const getNodeRequestOptions = request => {
 	}
 
 	if (!headers.has('Connection') && !agent) {
-		headers.set('Connection', 'close');
+		headers.set('Connection', 'keep-alive');
 	}
 
 	// HTTP-network fetch step 4.2


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Use `keep-alive` by default for `Connection` header.

## Changes

Replace `close` by `keep-alive`.

## Additional information

Chromium and Firefox use `keep-alive` by default for `Connection` header.
[MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection) specifies `close` is the default value for _HTTP 1.0_. And usually, it's `keep-alive` for _HTTP 1.1_ (version used by [Node.js](https://github.com/nodejs/node/blob/master/lib/_http_client.js#L289)).

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I updated ./docs/v3-UPGRADE-GUIDE
- [x] I updated readme
- [ ] I added unit test(s)