### PR TITLE
fix: Prevent unsubscribe from leaking listeners (#1295)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -387,13 +387,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 		};
 
-		socket.prependListener('close', onSocketClose);
-
-		request.on('abort', () => {
-			socket.removeListener('close', onSocketClose);
-		});
-
-		socket.on('data', buf => {
+		const onData = buf => {
 			properLastChunkReceived = Buffer.compare(buf.slice(-5), LAST_CHUNK) === 0;
 
 			// Sometimes final 0-length chunk and end of message code are in separate packets
@@ -405,6 +399,14 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 			}
 
 			previousChunk = buf;
+		};
+
+		socket.prependListener('close', onSocketClose);
+		socket.on('data', onData);
+
+		request.on('close', () => {
+			socket.removeListener('close', onSocketClose);
+			socket.removeListener('data', onData);
 		});
 	});
 }


### PR DESCRIPTION
Since 8eeeec1 it seems listeners have been leaking on keep-alive sockets.

Apparently abort() has been deprecated since v17, using close() the onSocketClose listener is properly removed, and by creating a new onData function I'm able to remove the 'data' listener too.

___

- [ ] I updated ./docs/CHANGELOG.md with a link to this PR or Issue
- [ ] I updated ./docs/v3-UPGRADE-GUIDE
- [ ] I updated readme
- [ ] I added unit test(s)

___
- fix #1295
