### PR TITLE
chore: adding whatwg stream utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,10 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^4.0.0",
+    "end-of-stream": "^1.4.4",
     "fetch-blob": "^3.1.4",
-    "formdata-polyfill": "^4.0.10"
+    "formdata-polyfill": "^4.0.10",
+    "web-streams-polyfill": "^3.2.0"
   },
   "tsd": {
     "cwd": "@types",
@@ -78,7 +80,9 @@
       "browser"
     ],
     "ignores": [
-      "example.js"
+      "example.js",
+      "test/whatwg.js",
+      "src/utils/streams.js"
     ],
     "rules": {
       "complexity": 0,

--- a/src/utils/streams.js
+++ b/src/utils/streams.js
@@ -1,0 +1,143 @@
+import process from 'node:process'
+import stream from 'node:stream'
+import zlib from 'node:zlib'
+import eos from 'end-of-stream'
+
+const { emitWarning } = process
+process.emitWarning = () => { }
+const { default: _, DecompressionStream = zlib.createUnzip, ...whatwg } = (
+  /** @type {import('node:stream/web')} */
+  (await import('node:stream/web').catch(_ =>
+    import('web-streams-polyfill/dist/ponyfill.es2018.js')
+  ))
+)
+process.emitWarning = emitWarning
+
+class Duplex extends stream.Duplex {
+  /** @param {Duplex} duplex */
+  toWeb (duplex) {
+    return {
+      writable: Writable.toWeb(duplex),
+      readable: Readable.toWeb(duplex)
+    }
+  }
+}
+
+function defer () {
+  const q = {}
+  q.promise = new Promise((rs, rj) => {
+    q.resolve = rs
+    q.reject = rj
+  })
+  return q
+}
+
+// Have been end():d.
+function isWritableEnded (stream) {
+  if (stream.writableEnded === true) return true
+  const wState = stream._writableState
+  if (wState?.errored) return false
+  if (typeof wState?.ended !== 'boolean') return null
+  return wState.ended
+}
+
+class Writable extends stream.Writable {
+  /** @param {stream.Writable} writable */
+  toWeb (writable) {
+    let q
+    let closed
+
+    return new whatwg.WritableStream({
+      start (controller) {
+        const cleanup = eos(writable, error => {
+          cleanup()
+          if (error != null) {
+            if (q) q.reject(error)
+            // If closed is not undefined, the error is happening
+            // after the WritableStream close has already started.
+            // We need to reject it here.
+            if (closed !== undefined) {
+              closed.reject(error)
+              closed = undefined
+            }
+            controller.error(error)
+            controller = undefined
+            return
+          }
+
+          if (closed) {
+            closed.resolve()
+            closed = undefined
+            return
+          }
+          controller.error(error)
+          controller = undefined
+        })
+
+        writable.on('drain', () => {
+          if (q) q.resolve()
+        })
+      },
+
+      async write (chunk) {
+        if (writable.writableNeedDrain || !writable.write(chunk)) {
+          q = defer()
+          return q.promise.finally(() => {
+            q = undefined
+          })
+        }
+      },
+
+      abort (reason) {
+        writable.destroy(reason)
+      },
+
+      close () {
+        if (!closed && !isWritableEnded(writable)) {
+          closed = defer()
+          writable.end()
+          return closed.promise
+        }
+
+        return Promise.resolve()
+      }
+    }, { highWaterMark: writable.writableHighWaterMark })
+  }
+}
+
+class Readable extends stream.Readable {
+  /** @param {stream.Readable} readable */
+  static toWeb (readable) {
+    return new whatwg.ReadableStream({
+      start (controller) {
+        readable.pause()
+        const cleanup = eos(readable, error => {
+          cleanup()
+          error ? controller.error(error) : controller.close()
+        })
+
+        readable.on('data', (chunk) => {
+          controller.enqueue(new Uint8Array(chunk))
+          if (controller.desiredSize <= 0) readable.pause()
+        })
+      },
+      pull () { readable.resume() },
+      cancel (reason) { readable.destroy(reason) }
+    }, {
+      highWaterMark: readable.readableHighWaterMark
+    })
+  }
+}
+
+// Use built-in Node.js stuff if available
+Readable.toWeb = stream.Readable.toWeb || Readable.toWeb
+Writable.toWeb = stream.Writable.toWeb || Writable.toWeb
+Duplex.toWeb = stream.Duplex.toWeb || Duplex.toWeb
+
+export {
+  DecompressionStream,
+  Readable,
+  Writable,
+  Duplex,
+  whatwg
+}

--- a/test/whatwg.js
+++ b/test/whatwg.js
@@ -1,0 +1,57 @@
+import https from 'node:https'
+import { createBrotliDecompress } from 'node:zlib'
+import assert from 'node:assert'
+import { json } from 'stream-consumers'
+import { Blob } from '../src/index.js'
+import {
+  Readable,
+  Duplex,
+  DecompressionStream,
+  whatwg
+} from '../src/utils/streams.js'
+
+/** @typedef {import('http').IncomingMessage} IncomingMessage */
+
+/** @type {(url: string) => Promise<IncomingMessage>} */
+const get = url => new Promise(rs => https.get(url, rs))
+
+describe('testing whatwg streams', () => {
+  it('should handle non compressed data', async () => {
+    const iterable = await get('https://httpbin.org/get').then(Readable.toWeb)
+    const data = await json(iterable)
+    assert(typeof data === 'object')
+  })
+
+  it('should decompress gzip', async () => {
+    const ts = new DecompressionStream('gzip')
+    const readable = await get('https://httpbin.org/gzip').then(Readable.toWeb)
+    const data = await json(readable.pipeThrough(ts))
+    assert(typeof data === 'object')
+  })
+
+  it('should decompress deflate', async () => {
+    const ts = new DecompressionStream('deflate')
+    const readable = await get('https://httpbin.org/deflate').then(Readable.toWeb)
+    const data = await json(readable.pipeThrough(ts))
+    assert(typeof data === 'object')
+  })
+
+  it('should decompress br', async () => {
+    const ts = Duplex.toWeb(createBrotliDecompress())
+    const readable = await get('https://httpbin.org/brotli').then(Readable.toWeb)
+    const data = await json(readable.pipeThrough(ts))
+    assert(typeof data === 'object')
+  })
+
+  it('should be able to pipe a blob and read it', async () => {
+    const chunks = []
+    await new Blob(['abc'])
+      .stream()
+      .pipeTo(new whatwg.WritableStream({
+        write (chunk) {
+          chunks.push(...chunk)
+        }
+      }))
+    assert.deepEqual(chunks, [97, 98, 99])
+  })
+})


### PR DESCRIPTION
Just some early utilities to bring whatwg streams to node-fetch@4

Ported & simplified 3 `toWeb` from NodeJS [streams@17](https://nodejs.org/dist/latest-v17.x/docs/api/stream.html) to be used by older node version

took roughly the same stuff from fetch-blob's stream.cjs on how it imports web streams


