### PR TITLE
fix: handle bom in text and json

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -145,8 +145,8 @@ export default class Body {
 	 * @return  Promise
 	 */
 	async json() {
-		const buffer = await consumeBody(this);
-		return JSON.parse(buffer.toString());
+		const text = await this.text();
+		return JSON.parse(text);
 	}
 
 	/**
@@ -156,7 +156,7 @@ export default class Body {
 	 */
 	async text() {
 		const buffer = await consumeBody(this);
-		return buffer.toString();
+		return new TextDecoder().decode(buffer);
 	}
 
 	/**

--- a/test/response.js
+++ b/test/response.js
@@ -77,9 +77,19 @@ describe('Response', () => {
 		expect(res.headers.get('a')).to.equal('1');
 	});
 
-	it('should decode responses containing BOM', async () => {
+	it('should decode responses containing BOM to json', async () => {
 		const json = await new Response('\uFEFF{"a":1}').json();
 		expect(json.a).to.equal(1);
+	});
+
+	it('should decode responses containing BOM to text', async () => {
+		const text = await new Response('\uFEFF{"a":1}').text();
+		expect(text).to.equal('{"a":1}');
+	});
+
+	it('should keep BOM when getting raw bytes', async () => {
+		const ab = await new Response('\uFEFF{"a":1}').arrayBuffer();
+		expect(ab.byteLength).to.equal(10);
 	});
 
 	it('should support text() method', () => {

--- a/test/response.js
+++ b/test/response.js
@@ -77,6 +77,11 @@ describe('Response', () => {
 		expect(res.headers.get('a')).to.equal('1');
 	});
 
+	it('should decode responses containing BOM', async () => {
+		const json = await new Response('\uFEFF{"a":1}').json();
+		expect(json.a).to.equal(1);
+	});
+
 	it('should support text() method', () => {
 		const res = new Response('a=1');
 		return res.text().then(result => {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
long over due problem to an easy fix... `.text()` & `.json()` didn't handle BOM correctly

## Changes
switch `buffer.toString()` to `TextDecoder().decode()`

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #541 
