### PR TITLE
chore: completely remove `.buffer()`

### DIFF
--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -21,9 +21,6 @@ async function run() {
 		}
 	}
 
-	// Test Buffer
-	expectType<Buffer>(await getResponse.buffer());
-
 	// Test arrayBuffer
 	expectType<ArrayBuffer>(await getResponse.arrayBuffer());
 

--- a/src/body.js
+++ b/src/body.js
@@ -158,18 +158,7 @@ export default class Body {
 		const buffer = await consumeBody(this);
 		return buffer.toString();
 	}
-
-	/**
-	 * Decode response as buffer (non-spec api)
-	 *
-	 * @return  Promise
-	 */
-	buffer() {
-		return consumeBody(this);
-	}
 }
-
-Body.prototype.buffer = deprecate(Body.prototype.buffer, 'Please use \'response.arrayBuffer()\' instead of \'response.buffer()\'', 'node-fetch#buffer');
 
 // In browsers, all properties are enumerable.
 Object.defineProperties(Body.prototype, {

--- a/test/main.js
+++ b/test/main.js
@@ -1857,7 +1857,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
 		});
 		return expect(
-			fetch(url).then(res => res.clone().buffer())
+			fetch(url).then(res => res.clone().arrayBuffer())
 		).to.timeout;
 	});
 
@@ -1869,7 +1869,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().arrayBuffer())
 		).to.timeout;
 	});
 
@@ -2079,13 +2079,13 @@ describe('node-fetch', () => {
 		expect(headers.a).to.equal('2');
 	});
 
-	it('should support arrayBuffer(), blob(), text(), json() and buffer() method in Body constructor', () => {
+	it('should support arrayBuffer(), blob(), text(), and json() method in Body constructor', () => {
 		const body = new Body('a=1');
 		expect(body).to.have.property('arrayBuffer');
 		expect(body).to.have.property('blob');
 		expect(body).to.have.property('text');
 		expect(body).to.have.property('json');
-		expect(body).to.have.property('buffer');
+		expect(body).to.not.have.property('buffer');
 	});
 
 	/* eslint-disable-next-line func-names */

--- a/test/main.js
+++ b/test/main.js
@@ -1886,7 +1886,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
 		});
 		return expect(
-			fetch(url).then(res => res.clone().buffer())
+			fetch(url).then(res => res.clone().arrayBuffer())
 		).not.to.timeout;
 	});
 
@@ -1903,7 +1903,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().arrayBuffer())
 		).not.to.timeout;
 	});
 
@@ -1918,7 +1918,7 @@ describe('node-fetch', () => {
 			res.end(crypto.randomBytes((2 * 512 * 1024) - 1));
 		});
 		return expect(
-			fetch(url, {highWaterMark: 512 * 1024}).then(res => res.clone().buffer())
+			fetch(url, {highWaterMark: 512 * 1024}).then(res => res.clone().arrayBuffer())
 		).not.to.timeout;
 	});
 

--- a/test/request.js
+++ b/test/request.js
@@ -189,18 +189,6 @@ describe('Request', () => {
 		});
 	});
 
-	it('should support buffer() method', () => {
-		const url = base;
-		const request = new Request(url, {
-			method: 'POST',
-			body: 'a=1'
-		});
-		expect(request.url).to.equal(url);
-		return request.buffer().then(result => {
-			expect(result.toString()).to.equal('a=1');
-		});
-	});
-
 	it('should support blob() method', async () => {
 		const url = base;
 		const request = new Request(url, {

--- a/test/response.js
+++ b/test/response.js
@@ -91,13 +91,6 @@ describe('Response', () => {
 		});
 	});
 
-	it('should support buffer() method', () => {
-		const res = new Response('a=1');
-		return res.buffer().then(result => {
-			expect(result.toString()).to.equal('a=1');
-		});
-	});
-
 	it('should support blob() method', () => {
 		const res = new Response('a=1', {
 			method: 'POST',


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
time to remove deprecated node-fetch only method `.buffer()`

## Changes


## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added & removed some unit test(s)

