### PR TITLE
chore: remove EventTarget from the isAbortSignal

### DIFF
--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -49,12 +49,7 @@ export const isBlob = object => {
  * @return {boolean}
  */
 export const isAbortSignal = object => {
-	return (
-		typeof object === 'object' && (
-			object[NAME] === 'AbortSignal' ||
-			object[NAME] === 'EventTarget'
-		)
-	);
+	return object?.[NAME] === 'AbortSignal';
 };
 
 /**

--- a/test/main.js
+++ b/test/main.js
@@ -1206,11 +1206,9 @@ describe('node-fetch', () => {
 
 	testAbortController('mysticatea', () => new AbortControllerMysticatea());
 
-	if (process.version > 'v15') {
-		testAbortController('native', () => new AbortController());
-	}
+	testAbortController('native', () => new AbortController());
 
-	it('should throw a TypeError if a signal is not of type AbortSignal or EventTarget', () => {
+	it('should throw a TypeError if a signal is not of type AbortSignal', () => {
 		return Promise.all([
 			expect(fetch(`${base}inspect`, {signal: {}}))
 				.to.be.eventually.rejected

--- a/test/main.js
+++ b/test/main.js
@@ -1206,7 +1206,9 @@ describe('node-fetch', () => {
 
 	testAbortController('mysticatea', () => new AbortControllerMysticatea());
 
-	testAbortController('native', () => new AbortController());
+	if (globalThis.AbortController) {
+		testAbortController('native', () => new globalThis.AbortController());
+	}
 
 	it('should throw a TypeError if a signal is not of type AbortSignal', () => {
 		return Promise.all([


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
should not check if a AbortSignal is of type EventTarget

## Changes


## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I changed unit test description

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1469
