### PR TITLE
chore: fix typo in credential error message

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -57,7 +57,7 @@ export default class Request extends Body {
 		}
 
 		if (parsedURL.username !== '' || parsedURL.password !== '') {
-			throw new TypeError(`${parsedURL} is an url with embedded credentails.`);
+			throw new TypeError(`${parsedURL} is an url with embedded credentials.`);
 		}
 
 		let method = init.method || input.method || 'GET';


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Was reading the code and found this typo. Easy fix

## Changes
credentails -> credentials