### PR TITLE
fix: TS types support `agent: false`

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 /// <reference lib="dom" />
 
-import {Agent} from 'http';
+import {RequestOptions} from 'http';
 import {
 	Blob,
 	blobFrom,
@@ -98,7 +98,7 @@ export interface RequestInit {
 	referrerPolicy?: ReferrerPolicy;
 
 	// Node-fetch extensions to the whatwg/fetch spec
-	agent?: Agent | ((parsedUrl: URL) => Agent);
+	agent?: RequestOptions['agent'] | ((parsedUrl: URL) => RequestOptions['agent']);
 	compress?: boolean;
 	counter?: number;
 	follow?: number;

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -78,6 +78,8 @@ async function run() {
 	expectAssignable<Body>(request);
 
 	/* eslint-disable no-new */
+	new Request('url', {agent: false});
+
 	new Headers({Header: 'value'});
 	// new Headers(['header', 'value']); // should not work
 	new Headers([['header', 'value']]);


### PR DESCRIPTION
## Purpose

The `agent` option is (after being potentially called as as function)
passed directly to `http.request`. This is allowed to be
a boolean; `http.request` interprets `agent: false` as
"allocate a one-off Agent for this request", which is
distinct from `agent: undefined` which means to use a
default shared agent.

## Changes

This PR updates the TS types to match the existing behavior.


- [x] I added unit test(s)
