### PR TITLE
fix: possible `Cannot read property 'startsWith' of null`

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -110,7 +110,7 @@ export default class Body {
 	async formData() {
 		const ct = this.headers.get('content-type');
 
-		if (ct.startsWith('application/x-www-form-urlencoded')) {
+		if (ct?.startsWith('application/x-www-form-urlencoded')) {
 			const formData = new FormData();
 			const parameters = new URLSearchParams(await this.text());
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
If the header is not set this function throws the error in the title of this pull request.

> I ran into this issue in `svelte-kit`: https://discord.com/channels/457912077277855764/939868205869072444/944634140811218975

## Changes
Added a question mark (optional chaining) to the if statement

## Additional information
Not sure if this is the correct fix for this problem. It 

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)
