### PR TITLE
fix: Add `ArrayBuffer` and views to the allowed `BodyInit` types

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -121,6 +121,8 @@ export interface ResponseInit {
 export type BodyInit =
 	| Blob
 	| Buffer
+	| ArrayBufferLike
+	| ArrayBufferView
 	| URLSearchParams
 	| FormData
 	| NodeJS.ReadableStream


### PR DESCRIPTION
## Purpose

The previous type definitions produced an error when assigning an `ArrayBuffer` or an `ArrayBufferView` to the `Request` body. However, [these cases are actually handled in the code](https://github.com/node-fetch/node-fetch/blob/6425e2021a7def096e13dbabcac2f10e6da83d11/src/body.js#L47-L52), so they should not produce an error.

## Changes

Add `ArrayBufferLike` and `ArrayBufferView` to the `BodyInit` union.

