### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -1003,9 +1003,7 @@ describe('node-fetch', () => {
 					}
 				});
 
-				setTimeout(() => {
-					controller.abort();
-				}, 100);
+				controller.abort();
 
 				return expect(promise)
 					.to.eventually.be.rejected
@@ -1029,9 +1027,7 @@ describe('node-fetch', () => {
 					})
 				];
 
-				setTimeout(() => {
-					controller.abort();
-				}, 100);
+				controller.abort();
 
 				return Promise.all(fetches.map(fetched => expect(fetched)
 					.to.eventually.be.rejected


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

By relying upon a 100ms delay before aborting, it is possible for the request to succeed before being canceled.

Since these 2 tests merely ensures that cancellation via AbortController works, adding a delay isn't needed regardless.

## Changes

Removes delay between request and canceling.

## Additional information

Undici runs node-fetch's test suite (more or less) and this test is flaky (https://github.com/nodejs/undici/runs/5153562802?check_suite_focus=true for example).

Example code with the issue fixed:
```js
import fetch from 'node-fetch';
import { createServer } from 'http';
import { once } from 'events';

const server = createServer((req, res) => res.end());
server.listen(3000, () => console.log('done'));
await once(server, 'listening');

let i = 1;
while (i++) {
	try {
		const controller = new AbortController();

		const promise = fetch(`http://localhost:3000/`, {
			method: 'POST',
			signal: controller.signal,
			headers: {
				'Content-Type': 'application/json',
				body: '{"hello": "world"}'
			}
		});

		controller.abort()

		const test = await promise;
		console.log('did not fail', test);
		break;
	} catch {
		if (i % 1e3 === 0) {
			console.log('did not fail after ' + i + ' tries');
		}
	}
}
```