### PR TITLE
Fix link syntax to Options definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ See [options](#fetch-options) for exact meaning of these extensions.
 <small>_(spec-compliant)_</small>
 
 - `input` A string representing a URL, or another `Request` (which will be cloned)
-- `options` [Options][#fetch-options] for the HTTP(S) request
+- `options` [Options](#fetch-options) for the HTTP(S) request
 
 Constructs a new `Request` object. The constructor is identical to that in the [browser](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request).
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

* Improve clarity and usability of documentation

## Changes

* Fix Markdown syntax to the Options definition

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
