### PR TITLE
docs: Code of Conduct link in Readme.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for considering to contribute to `node-fetch` 💖
 
-Please note that this project is released with a [Contributor Code of Conduct][./CODE_OF_CONDUCT.md].
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 By participating you agree to abide by its terms.
 
 ## Setup


### PR DESCRIPTION
## Purpose
To fix the broken Code of Conduct link in the README.md for the repo.

## Changes
Just one commit that fixes the link.

- [x] I updated readme

I don't think there is an issue related to this.
