### PR TITLE
fix: prevent hoisting of the undefined `global` variable in `browser.js`

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -11,15 +11,15 @@ var getGlobal = function () {
 	throw new Error('unable to locate global object');
 }
 
-var global = getGlobal();
+var globalObject = getGlobal();
 
-module.exports = exports = global.fetch;
+module.exports = exports = globalObject.fetch;
 
 // Needed for TypeScript and Webpack.
-if (global.fetch) {
-	exports.default = global.fetch.bind(global);
+if (globalObject.fetch) {
+	exports.default = globalObject.fetch.bind(global);
 }
 
-exports.Headers = global.Headers;
-exports.Request = global.Request;
-exports.Response = global.Response;
+exports.Headers = globalObject.Headers;
+exports.Request = globalObject.Request;
+exports.Response = globalObject.Response;


### PR DESCRIPTION
## Purpose

Because of JS hoisting `var global` to the top of the file, `typeof global` in `getGlobal()` will always be `undefined`.

This can be a problem when bundling this code and running it in an environment that doesn't have `self` of `window` defined but has `global`.

In practice I ran into this issue after browserifying node-fetch and running the bundle in `node --experimental-fetch` (just to test).

I can confirm after this fix I can browserify node-fetch and have it expose the global `fetch` function when run into `node --experimental-fetch`.

## Changes

By using a different variable name like `globalObject`, we are able to read the "real" `typeof global` and get access to the global object that way.