### PR TITLE
docs: Fix min nodejs version needed for AbortController

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ An example of timing out a request after 150ms could be achieved as the followin
 ```js
 import fetch, { AbortError } from 'node-fetch';
 
-// AbortController was added in node v14.17.0 globally
+// AbortController was added in node v15.0.0 globally
 const AbortController = globalThis.AbortController || await import('abort-controller')
 
 const controller = new AbortController();


### PR DESCRIPTION
After testing that and checking the docs it seems that AbortController was introduced in v15.0.0 not in v14.17.0
https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility