### PR TITLE
fix: don't uppercase unknown methods

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -61,7 +61,9 @@ export default class Request extends Body {
 		}
 
 		let method = init.method || input.method || 'GET';
-		method = method.toUpperCase();
+		if (/^(DELETE|GET|HEAD|OPTIONS|POST|PUT)$/i.test(method)) {
+			method = method.toUpperCase();
+		}
 
 		if ('data' in init) {
 			doBadDataWarn();

--- a/src/request.js
+++ b/src/request.js
@@ -61,7 +61,7 @@ export default class Request extends Body {
 		}
 
 		let method = init.method || input.method || 'GET';
-		if (/^(DELETE|GET|HEAD|OPTIONS|POST|PUT)$/i.test(method)) {
+		if (/^(delete|get|head|options|post|put)$/i.test(method)) {
 			method = method.toUpperCase();
 		}
 

--- a/test/request.js
+++ b/test/request.js
@@ -155,7 +155,7 @@ describe('Request', () => {
 		const url = base;
 		for (const method of ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']) {
 			const request = new Request(url, {
-				method: method.toLowerCase(),
+				method: method.toLowerCase()
 			});
 			expect(request.method).to.equal(method);
 		}
@@ -163,8 +163,8 @@ describe('Request', () => {
 
 	it('should not uppercase unknown methods and patch', () => {
 		const url = base;
-		for (const method of ['patch', 'chicken',]) {
-			const request = new Request(url, { method });
+		for (const method of ['patch', 'chicken']) {
+			const request = new Request(url, {method});
 			expect(request.method).to.equal(method);
 		}
 	});

--- a/test/request.js
+++ b/test/request.js
@@ -151,6 +151,24 @@ describe('Request', () => {
 		expect(request.headers.get('a')).to.equal('1');
 	});
 
+	it('should uppercase DELETE, GET, HEAD, OPTIONS, POST and PUT methods', () => {
+		const url = base;
+		for (const method of ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']) {
+			const request = new Request(url, {
+				method: method.toLowerCase(),
+			});
+			expect(request.method).to.equal(method);
+		}
+	});
+
+	it('should not uppercase unknown methods and patch', () => {
+		const url = base;
+		for (const method of ['patch', 'chicken',]) {
+			const request = new Request(url, { method });
+			expect(request.method).to.equal(method);
+		}
+	});
+
 	it('should support arrayBuffer() method', () => {
 		const url = base;
 		const request = new Request(url, {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
The purpose is to follow [Fetch Spec](https://fetch.spec.whatwg.org/#concept-method-normalize) 

## Changes

As per spec:
To normalize a method, if it is a byte-case-insensitive match for `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, or `PUT`, byte-uppercase it. 

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1538
