### PR TITLE
fix: always warn Request.data

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -65,7 +65,7 @@ export default class Request extends Body {
 			method = method.toUpperCase();
 		}
 
-		if ('data' in init) {
+		if (!isRequest(init) && 'data' in init) {
 			doBadDataWarn();
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Avoid warn `Request.data`, even if it is not used 


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1549
