### PR TITLE
fix: always abort socket if consumeBody throw error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn.lock
 
 # Ignore IDE
 .idea
+.vscode


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
always abort socket if `consumeBody` throw error.

## Changes

ensure to call `body.destroy()` if `consumeBody` throw error.

## Additional information

There is [a same issue](https://github.com/node-fetch/node-fetch/pull/1557) for v2, and [a demo](https://github.com/MoonBall/node-fetch-hangup-demo) for v2. 

For v3, I just throw Error [in this line](https://github.com/node-fetch/node-fetch/blob/main/src/body.js#L221) to make socket hangup.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
