### PR TITLE
docs(readme): remove `async` infront of `response.clone()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ The recommended way to fix this problem is to resolve cloned response in paralle
 import fetch from 'node-fetch';
 
 const response = await fetch('https://example.com');
-const r1 = await response.clone();
+const r1 = response.clone();
 
 const results = await Promise.all([response.json(), r1.text()]);
 


### PR DESCRIPTION

<!-- Thanks for contributing! -->

## Purpose

Reduce confusion


## Changes

Update readme to remove an awaited `response.clone()` call in the `highWaterMark` section.

## Additional information

source code shows response is a sync call to a new Response constructor: https://github.com/node-fetch/node-fetch/blob/3944f24770b442e519eaff758adffc9ca0092bdb/src/response.js#L84-L101

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated readme

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
