### PR TITLE
fix: undefined reference to response.body when aborted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,9 @@ export default async function fetch(url, options_) {
 		});
 
 		fixResponseChunkedTransferBadEnding(request_, error => {
-			response.body.destroy(error);
+			if (response && response.body) {
+				response.body.destroy(error);
+			}
 		});
 
 		/* c8 ignore next 18 */


### PR DESCRIPTION
## Purpose
Fixes a bug where `response.body` doesn't exist during some portion of the request lifespan (likely when aborted manually)

## Changes
Check if both `response` and `response.body` exist before trying to destroy.

___

- [ ] I updated readme
- [ ] I added unit test(s)
