### PR TITLE
fix: ReDoS referrer

### DIFF
--- a/src/utils/referrer.js
+++ b/src/utils/referrer.js
@@ -119,7 +119,7 @@ export function isOriginPotentiallyTrustworthy(url) {
 	// 5. If origin's host component is "localhost" or falls within ".localhost", and the user agent conforms to the name resolution rules in [let-localhost-be-localhost], return "Potentially Trustworthy".
 	// We are returning FALSE here because we cannot ensure conformance to
 	// let-localhost-be-loalhost (https://tools.ietf.org/html/draft-west-let-localhost-be-localhost)
-	if (/^(.+)\.localhost$/.test(url.host)) {
+	if (url.host === 'localhost' || url.host.endsWith('.localhost')) {
 		return false;
 	}
 

--- a/src/utils/referrer.js
+++ b/src/utils/referrer.js
@@ -119,7 +119,7 @@ export function isOriginPotentiallyTrustworthy(url) {
 	// 5. If origin's host component is "localhost" or falls within ".localhost", and the user agent conforms to the name resolution rules in [let-localhost-be-localhost], return "Potentially Trustworthy".
 	// We are returning FALSE here because we cannot ensure conformance to
 	// let-localhost-be-loalhost (https://tools.ietf.org/html/draft-west-let-localhost-be-localhost)
-	if (/^(.+\.)*localhost$/.test(url.host)) {
+	if (/^(.+)\.localhost$/.test(url.host)) {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Fix Inefficient Regular Expression Complexity (ReDoS) in the referrer regex.
> Inefficient regular expression complexity regex when trying to match Potentially Trustworthy could lead to a denial of service attack. With a formed payload 'http://' + 'a.a.'.repeat(i) + 'a', 76 characters payload could take 42642 ms time execution. 

## Changes
- Change `Potentially Trustworthy` regex matcher.

## Additional information
- [Report on Huntr](https://huntr.dev/bounties/a7e6a136-0a4b-46c4-ad20-802f1dd60bf7/)

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix [#1609](https://github.com/node-fetch/node-fetch/issues/1609)
