### PR TITLE
Remove unnecessary await import() call

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -15,6 +15,7 @@ import {FormData, formDataToBlob} from 'formdata-polyfill/esm.min.js';
 import {FetchError} from './errors/fetch-error.js';
 import {FetchBaseError} from './errors/base.js';
 import {isBlob, isURLSearchParameters} from './utils/is.js';
+import {toFormData} from "./utils/multipart-parser.js";
 
 const pipeline = promisify(Stream.pipeline);
 const INTERNALS = Symbol('Body internals');
@@ -121,7 +122,6 @@ export default class Body {
 			return formData;
 		}
 
-		const {toFormData} = await import('./utils/multipart-parser.js');
 		return toFormData(this.body, ct);
 	}
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

<!-- Thanks for contributing! -->

## Purpose
I have a need to use webpack to bundle node-fetch targeting "electron-renderer" and it would be very useful to only have a single file as output. However, because of this `await import()` call, webpack generates two files.

## Changes
- Change an `await import()` to `import { ... } from "..."`

## Additional information
