### PR TITLE
propagate `highWaterMark` across redirects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,8 @@ export default async function fetch(url, options_) {
 							signal: request.signal,
 							size: request.size,
 							referrer: request.referrer,
-							referrerPolicy: request.referrerPolicy
+							referrerPolicy: request.referrerPolicy,
+				      highWaterMark: request.highWaterMark
 						};
 
 						// when forwarding sensitive headers like "Authorization",


### PR DESCRIPTION
Propagate `highWaterMark` across redirects so that it ends in the final response

