### PR TITLE
Remove header sorting when iterates over it

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -105,7 +105,7 @@ export default class Headers extends URLSearchParams {
 
 		super(result);
 
-		// Returning a Proxy that will lowercase key names, validate parameters and sort keys
+		// Returning a Proxy that will lowercase key names, validate parameters
 		// eslint-disable-next-line no-constructor-return
 		return new Proxy(this, {
 			get(target, p, receiver) {
@@ -135,7 +135,6 @@ export default class Headers extends URLSearchParams {
 
 					case 'keys':
 						return () => {
-							// target.sort();
 							return new Set(URLSearchParams.prototype.keys.call(target)).keys();
 						};
 

--- a/src/headers.js
+++ b/src/headers.js
@@ -135,7 +135,7 @@ export default class Headers extends URLSearchParams {
 
 					case 'keys':
 						return () => {
-							target.sort();
+							// target.sort();
 							return new Set(URLSearchParams.prototype.keys.call(target)).keys();
 						};
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -47,9 +47,9 @@ describe('Headers', () => {
 		}
 
 		expect(result).to.deep.equal([
-			['a', '1'],
 			['b', '2, 3'],
-			['c', '4']
+			['c', '4'],
+			['a', '1'],
 		]);
 	});
 
@@ -99,9 +99,9 @@ describe('Headers', () => {
 		}
 
 		expect(result).to.deep.equal([
-			['a', '1'],
 			['b', '2, 3'],
-			['c', '4']
+			['c', '4'],
+			['a', '1'],
 		]);
 	});
 
@@ -115,9 +115,9 @@ describe('Headers', () => {
 
 		expect(headers.entries()).to.be.iterable
 			.and.to.deep.iterate.over([
-				['a', '1'],
 				['b', '2, 3'],
-				['c', '4']
+				['c', '4'],
+				['a', '1'],
 			]);
 	});
 
@@ -130,7 +130,7 @@ describe('Headers', () => {
 		headers.append('b', '3');
 
 		expect(headers.keys()).to.be.iterable
-			.and.to.iterate.over(['a', 'b', 'c']);
+			.and.to.iterate.over(['b', 'c', 'a']);
 	});
 
 	it('should allow iterating through all headers with values()', () => {
@@ -142,7 +142,7 @@ describe('Headers', () => {
 		headers.append('b', '3');
 
 		expect(headers.values()).to.be.iterable
-			.and.to.iterate.over(['1', '2, 3', '4']);
+			.and.to.iterate.over(['2, 3', '4', '1']);
 	});
 
 	it('should reject illegal header', () => {
@@ -273,6 +273,5 @@ describe('Headers', () => {
 		]);
 
 		// eslint-disable-next-line quotes
-		expect(format(headers)).to.equal("{ a: [ '1', '3' ], b: '2', host: 'thehost' }");
-	});
+		expect(format(headers)).to.equal("{ host: 'thehost', a: [ '1', '3' ], b: '2' }"); });
 });


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Keep headers order while sending them.

## Changes

Remove sorting function when iterates over it.
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix [1569](https://github.com/node-fetch/node-fetch/issues/1569)
