### PR TITLE
[#1576] Fixes unexpected premature close on chunked responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -397,10 +397,10 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 
 			// Sometimes final 0-length chunk and end of message code are in separate packets
 			if (!properLastChunkReceived && previousChunk) {
-				properLastChunkReceived = (
-					Buffer.compare(previousChunk.slice(-3), LAST_CHUNK.slice(0, 3)) === 0 &&
-					Buffer.compare(buf.slice(-2), LAST_CHUNK.slice(3)) === 0
-				);
+				if (buf.length < 5) {
+					properLastChunkReceived = Buffer.compare(
+						Buffer.from([...previousChunk.slice(-5), ...buf]).slice(-5), LAST_CHUNK) === 0;
+				}
 			}
 
 			previousChunk = buf;


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Fixes #1576 (unexpected premature close errors on chunked responses)

## Changes

It corrects a false assumption about split of the 'LAST CHUNK' marker between the previous and current buffer. The new solution concatenates last bytes of the previous buffer with all bytes from the current buffer (if that holds less then 5 bytes) and does the check on that.

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1576
