### PR TITLE
Provide a single param to request (issue #1620)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default async function fetch(url, options_) {
 		};
 
 		// Send request
-		const request_ = send(parsedURL.toString(), options);
+		const request_ = send(options);
 
 		if (signal) {
 			signal.addEventListener('abort', abortAndFinalize);

--- a/src/request.js
+++ b/src/request.js
@@ -297,17 +297,30 @@ export const getNodeRequestOptions = request => {
 
 	const search = getSearch(parsedURL);
 
-	// Pass the full URL directly to request(), but overwrite the following
-	// options:
+	// Provide full options from URL (issue #1620)
 	const options = {
+		protocol: parsedURL.protocol,
+		hostname: parsedURL.hostname.startsWith("[") && parsedURL.hostname.endsWith("]") ? parsedURL.hostname.slice(1, -1) : parsedURL.hostname,
+		pathname: parsedURL.pathname,
 		// Overwrite search to retain trailing ? (issue #776)
 		path: parsedURL.pathname + search,
+		search: parsedURL.search,
+		hash: parsedURL.hash,
+		href: parsedURL.href,
 		// The following options are not expressed in the URL
 		method: request.method,
 		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
 		insecureHTTPParser: request.insecureHTTPParser,
 		agent
 	};
+
+	if (parsedURL.username || parsedURL.password) {
+		options.auth = `${decodeURIComponent(parsedURL.username)}:${decodeURIComponent(parsedURL.password)}`;
+	}
+
+	if (parsedURL.port !== '') {
+		options.port = Number(parsedURL.port);
+	}
 
 	return {
 		/** @type {URL} */


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Provide a single argument to http request function.

## Changes
Put all information in option object and do not provide url separately

## Additional information


___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1620 
