### PR TITLE
Allow URL class object as an argument for fetch()

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -145,9 +145,9 @@ export interface Body extends Pick<BodyMixin, keyof BodyMixin> {}
 
 export type RequestRedirect = 'error' | 'follow' | 'manual';
 export type ReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'same-origin' | 'origin' | 'strict-origin' | 'origin-when-cross-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
-export type RequestInfo = string | URL | Request;
+export type RequestInfo = string | Request;
 export class Request extends BodyMixin {
-	constructor(input: RequestInfo, init?: RequestInit);
+	constructor(input: RequestInfo | URL, init?: RequestInit);
 
 	/**
 	 * Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
@@ -216,4 +216,4 @@ export class AbortError extends Error {
 }
 
 export function isRedirect(code: number): boolean;
-export default function fetch(url: RequestInfo, init?: RequestInit): Promise<Response>;
+export default function fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response>;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -145,7 +145,7 @@ export interface Body extends Pick<BodyMixin, keyof BodyMixin> {}
 
 export type RequestRedirect = 'error' | 'follow' | 'manual';
 export type ReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'same-origin' | 'origin' | 'strict-origin' | 'origin-when-cross-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
-export type RequestInfo = string | Request;
+export type RequestInfo = string | URL | Request;
 export class Request extends BodyMixin {
 	constructor(input: RequestInfo, init?: RequestInit);
 

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -37,6 +37,7 @@ async function run() {
 	// Post
 	try {
 		const request = new Request('http://byjka.com/buka');
+		new Request(new URL('http://byjka.com/buka'));
 		expectType<string>(request.url);
 		expectType<Headers>(request.headers);
 

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -7,6 +7,7 @@ import * as _fetch from '.';
 
 async function run() {
 	const getResponse = await fetch('https://bigfile.com/test.zip');
+	await fetch(new URL('https://bigfile.com/test.zip'));
 	expectType<boolean>(getResponse.ok);
 	expectType<number>(getResponse.size);
 	expectType<number>(getResponse.status);


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Fixes https://github.com/node-fetch/node-fetch/issues/1261

## Changes

Added `URL` to `fetch` and `Request` constructor

## Additional information

Inspired by: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a9f480c82b3b356990e5dd574bf2c1ba9c2fdfb5/types/node-fetch/index.d.ts#L213 and https://github.com/microsoft/TypeScript/blob/f43cd0accac3e5033820fd27035731ed88f54938/lib/lib.dom.d.ts#L18281
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I added unit test

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1261
