### PR TITLE
Prevent error when response is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,9 @@ export default function fetch(url, opts) {
 				return
 			}
 
-			destroyStream(response.body, err);
+			if (response && response.body) {
+				destroyStream(response.body, err);
+			}
 		});
 
 		/* c8 ignore next 18 */


### PR DESCRIPTION
## Purpose

Fix for this error.
TypeError: Cannot read properties of null (reading 'body')


## Changes

Check if body exist

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

- fix #1700
- fix #1701