### PR TITLE
Fix "global is not defined"

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -17,7 +17,7 @@ module.exports = exports = globalObject.fetch;
 
 // Needed for TypeScript and Webpack.
 if (globalObject.fetch) {
-	exports.default = globalObject.fetch.bind(global);
+	exports.default = globalObject.fetch.bind(globalObject);
 }
 
 exports.Headers = globalObject.Headers;


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
I think this was missed in https://github.com/node-fetch/node-fetch/pull/1534

## Changes
Replace `global` -> `globalObject`

## Additional information
I get a `global is not defined` error otherwise. (octokit is still using this instead of isomorphic-fetch/cross-fetch)
