### PR TITLE
docs: readme - non ESM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ results in an [opaque-redirect filtered response](https://fetch.spec.whatwg.org/
 node-fetch gives you the typical [basic filtered response](https://fetch.spec.whatwg.org/#concept-filtered-response-basic) instead.
 
 ```js
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 
 const response = await fetch('https://httpbin.org/status/301', { redirect: 'manual' });
 


### PR DESCRIPTION
## Purpose
Fix old example in the README.md file.

## Changes
require -> import

## Additional information
according to different part of the same document
 > node-fetch from v3 is an ESM-only module - you are not able to import it with require()
