### PR TITLE
fix: release "Allow URL class object as an argument for fetch()" #1696

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -147,7 +147,7 @@ export type RequestRedirect = 'error' | 'follow' | 'manual';
 export type ReferrerPolicy = '' | 'no-referrer' | 'no-referrer-when-downgrade' | 'same-origin' | 'origin' | 'strict-origin' | 'origin-when-cross-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
 export type RequestInfo = string | Request;
 export class Request extends BodyMixin {
-	constructor(input: RequestInfo | URL, init?: RequestInit);
+	constructor(input: URL | RequestInfo, init?: RequestInit);
 
 	/**
 	 * Returns a Headers object consisting of the headers associated with request. Note that headers added in the network layer by the user agent will not be accounted for in this object, e.g., the "Host" header.
@@ -216,4 +216,4 @@ export class AbortError extends Error {
 }
 
 export function isRedirect(code: number): boolean;
-export default function fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+export default function fetch(url: URL | RequestInfo, init?: RequestInit): Promise<Response>;


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Dummy change with `fix:` commit to trigger the release of https://github.com/node-fetch/node-fetch/pull/1696

## Changes
Swapped `RequestInfo | URL` around to `URL | RequestInfo` 🤷‍♂️

## Additional information
CI fail is irrelevant, same as [before](https://github.com/node-fetch/node-fetch/pull/1696/checks)