### PR TITLE
Fix for allowing POST request with formdata-node using response.body stream as body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,7 +403,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 				);
 			}
 
-			previousChunk = buf;
+			previousChunk = Buffer.from(buf);
 		};
 
 		socket.prependListener('close', onSocketClose);

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -469,11 +469,13 @@ export default class TestServer {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'application/json');
 			const bb = busboy({headers: request.headers});
+			let fileLength = 0;
 			bb.on('file', async (fieldName, file, info) => {
 				body += `${fieldName}=${info.filename}`;
 				// consume file data
-				// eslint-disable-next-line no-empty, no-unused-vars
-				for await (const c of file) {}
+				for await (const chunk of file) {
+					fileLength += chunk.length;
+				}
 			});
 			bb.on('field', (fieldName, value) => {
 				body += `${fieldName}=${value}`;
@@ -483,7 +485,8 @@ export default class TestServer {
 					method: request.method,
 					url: request.url,
 					headers: request.headers,
-					body
+					body,
+					file: {size: fileLength}
 				}));
 			});
 			request.pipe(bb);

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -497,5 +497,11 @@ export default class TestServer {
 			res.setHeader('Content-Type', 'text/plain');
 			res.end('ok');
 		}
+
+		if (p === '/64kb_file') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/plain');
+			res.end(Buffer.alloc(64 * 1024, '_'));
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
It should be possible to use `response.body` of one `fetch` request as the source body for the second `fetch` request, using `formdata-node`. This allows downloading file from one remote server and uploading it, as it's downloaded, to another remote server (on-the-fly, without writing to disc). This was not possible due to a `Cannot perform Construct on a detached ArrayBuffer` error.

## Changes
- Copy the buffer when setting `previousChunk` instead of passing it by reference.
- Enhance `TestServer` instance to allow new test cases.
- Added `should allow POST request with formdata-node using response.body stream as body` test case.

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I added test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1718
