### PR TITLE
fix: socket variable testing for undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,14 +362,13 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 		const {headers} = response;
 		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
 			response.once('close', hadError => {
-				// if for some reason the 'socket' event was not triggered
-				// for the request (happens in deno) avoids `TypeError`
-				if (socket === undefined) {
-					return;
+				// tests for socket presence, as in some situations the
+				// the 'socket' event is not triggered for the request
+				// (happens in deno), avoids `TypeError`
+				if (socket !== undefined) {
+					// if a data listener is still present we didn't end cleanly
+					const hasDataListener = socket.listenerCount('data') > 0;
 				}
-
-				// if a data listener is still present we didn't end cleanly
-				const hasDataListener = socket.listenerCount('data') > 0;
 
 				if (hasDataListener && !hadError) {
 					const err = new Error('Premature close');

--- a/src/index.js
+++ b/src/index.js
@@ -362,6 +362,12 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 		const {headers} = response;
 		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
 			response.once('close', hadError => {
+				// if for some reason the 'socket' event was not triggered
+				// for the request (happens in deno) avoids `TypeError`
+				if (socket === undefined) {
+					return;
+				}
+
 				// if a data listener is still present we didn't end cleanly
 				const hasDataListener = socket.listenerCount('data') > 0;
 

--- a/src/index.js
+++ b/src/index.js
@@ -365,11 +365,8 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 				// tests for socket presence, as in some situations the
 				// the 'socket' event is not triggered for the request
 				// (happens in deno), avoids `TypeError`
-                                let hasDataListener
-				if (socket !== undefined) {
-					// if a data listener is still present we didn't end cleanly
-					hasDataListener = socket.listenerCount('data') > 0;
-				}
+        // if a data listener is still present we didn't end cleanly
+				const hasDataListener = socket && socket.listenerCount('data') > 0;
 
 				if (hasDataListener && !hadError) {
 					const err = new Error('Premature close');

--- a/src/index.js
+++ b/src/index.js
@@ -365,9 +365,10 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 				// tests for socket presence, as in some situations the
 				// the 'socket' event is not triggered for the request
 				// (happens in deno), avoids `TypeError`
+                                let hasDataListener
 				if (socket !== undefined) {
 					// if a data listener is still present we didn't end cleanly
-					const hasDataListener = socket.listenerCount('data') > 0;
+					hasDataListener = socket.listenerCount('data') > 0;
 				}
 
 				if (hasDataListener && !hadError) {


### PR DESCRIPTION
Avoid issue where socket event was not triggered and local socket variable is not defined. This issue is reproducible only using deno.

## Purpose

#1725

## Changes

Adds undefined testing to socket variable, protecting it from TypeError.

___

- fix #1725
