### PR TITLE
fix: Remove the default connection close header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,6 @@ If no values are set, the following request headers will be sent automatically:
 | ------------------- | ------------------------------------------------------ |
 | `Accept-Encoding`   | `gzip, deflate, br` (when `options.compress === true`) |
 | `Accept`            | `*/*`                                                  |
-| `Connection`        | `close` _(when no `options.agent` is present)_         |
 | `Content-Length`    | _(automatically calculated, if possible)_              |
 | `Host`              | _(host and port information from the target URI)_      |
 | `Transfer-Encoding` | `chunked` _(when `req.body` is a stream)_              |
@@ -557,6 +556,8 @@ The `agent` option allows you to specify networking related options which are ou
 - Custom DNS Lookup
 
 See [`http.Agent`](https://nodejs.org/api/http.html#http_new_agent_options) for more information.
+
+If no agent is specified, the default agent provided by Node.js is used. Note that [this changed in Node.js 19](https://github.com/nodejs/node/blob/4267b92604ad78584244488e7f7508a690cb80d0/lib/_http_agent.js#L564) to have `keepalive` true by default. If you wish to enable `keepalive` in an earlier version of Node.js, you can override the agent as per the following code sample. 
 
 In addition, the `agent` option accepts a function that returns `http`(s)`.Agent` instance given current [URL](https://nodejs.org/api/url.html), this is useful during a redirection chain across HTTP and HTTPS protocol.
 

--- a/src/request.js
+++ b/src/request.js
@@ -288,10 +288,6 @@ export const getNodeRequestOptions = request => {
 		agent = agent(parsedURL);
 	}
 
-	if (!headers.has('Connection') && !agent) {
-		headers.set('Connection', 'close');
-	}
-
 	// HTTP-network fetch step 4.2
 	// chunked encoding is handled by Node.js
 


### PR DESCRIPTION
## Purpose
This fixes #1735 and likely replaces #1473.

## Changes

Removes the behaviour to add a `Connection: close` header. This was causing issues in Node.js 19+ (see #1735), but possibly subtle issues in earlier Node.js too. Note that we still expect some users to use `node-fetch` in Node.js 19+ because enabling fetch requires an `--experimental-fetch` command line parameter passed to Node.js and some users (such as people consuming my library which requires a `fetch` implementation) require it.

Instead, we rely on the underlying http implementation in Node.js to handle this, as per the documentation at
https://nodejs.org/api/http.html#new-agentoptions

The [original change introducing this](https://github.com/node-fetch/node-fetch/commit/af21ae6c1c964cd40e48e974af56ea2e1361304f) provided no clear motivation for providing the header, and [the implementation has since been changed to disable this header when an agent is provided](https://github.com/node-fetch/node-fetch/commit/7f68577de44c7d1efe7009b212f7c54a0b4a709b), so I think there is sufficient evidence that removing this header is the correct behaviour.  

If this change is accepted, I'm happy to back-port this into the 2.x branch, as I know some users of my library use 2.x because they can't use ESM.

## Additional information
See  #1735 for background.

___

- [X] I updated the readme
(I didn't add unit tests because the behaviour now depends the presence of the header now depends on the default http agent behaviour, and therefore on the Node.js version being used and I didn't want to introduce that dependency into the tests)

___

- fix #1735 
- replaces #1473 
