### PR TITLE
fix: handle bom in text and json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dependencies": {
         "whatwg-url": "^5.0.0"
     },
-    "peerDependencies": { 
+    "peerDependencies": {
         "encoding": "^0.1.0"
     },
     "peerDependenciesMeta": {

--- a/src/body.js
+++ b/src/body.js
@@ -114,12 +114,8 @@ Body.prototype = {
 	 * @return  Promise
 	 */
 	json() {
-		return consumeBody.call(this).then((buffer) => {
-			try {
-				return JSON.parse(buffer.toString());
-			} catch (err) {
-				return Body.Promise.reject(new FetchError(`invalid json response body at ${this.url} reason: ${err.message}`, 'invalid-json'));
-			}
+		return this.text.then((text) => {
+			return JSON.parse(text); 
 		})
 	},
 
@@ -129,7 +125,7 @@ Body.prototype = {
 	 * @return  Promise
 	 */
 	text() {
-		return consumeBody.call(this).then(buffer => buffer.toString());
+		return consumeBody.call(this).then(buffer => new TextDecoder().decode(buffer));
 	},
 
 	/**

--- a/src/body.js
+++ b/src/body.js
@@ -114,8 +114,12 @@ Body.prototype = {
 	 * @return  Promise
 	 */
 	json() {
-		return this.text.then((text) => {
-			return JSON.parse(text); 
+		return this.text().then((text) => {
+			try{
+				return JSON.parse(text); 
+			} catch (err) {
+				return Body.Promise.reject(new FetchError(`invalid json response body at ${this.url} reason: ${err.message}`, 'invalid-json'));
+			}
 		})
 	},
 

--- a/test/test.js
+++ b/test/test.js
@@ -2479,6 +2479,21 @@ describe('Response', function () {
 		expect(res.headers.get('a')).to.equal('1');
 	});
 
+	it('should decode responses containing BOM to json', async () => {
+		const json = await new Response('\uFEFF{"a":1}').json();
+		expect(json.a).to.equal(1);
+	});
+
+	it('should decode responses containing BOM to text', async () => {
+		const text = await new Response('\uFEFF{"a":1}').text();
+		expect(text).to.equal('{"a":1}');
+	});
+
+	it('should keep BOM when getting raw bytes', async () => {
+		const ab = await new Response('\uFEFF{"a":1}').arrayBuffer();
+		expect(ab.byteLength).to.equal(10);
+	});
+
 	it('should support text() method', function() {
 		const res = new Response('a=1');
 		return res.text().then(result => {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Bring the fix https://github.com/node-fetch/node-fetch/pull/1482/commits from 3.X to 2.X

## Changes

Allow parsing results with BOM encoding

## Additional information

It's just a copy paste of the fix of https://github.com/node-fetch/node-fetch/pull/1482/commits for node-fetch 2.X, for the people who can't use 3.X
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
