### PR TITLE
feat: `AbortError`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -399,5 +399,6 @@ export {
 	Headers,
 	Request,
 	Response,
-	FetchError
+	FetchError,
+	AbortError
 };


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Backport of https://github.com/node-fetch/node-fetch/commit/553bb5dc5600b103905e3d40c722ebb387510a63 to v2.

## Changes
Exports the AbortError, which is used internally and thrown on a timeout. https://github.com/node-fetch/node-fetch/blob/2.x/src/index.js#L81

## Additional information
https://github.com/node-fetch/node-fetch/issues/792

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

- fix #792
