### PR TITLE
Support rejectUnauthorized as an extended RequestInit option

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -109,6 +109,7 @@ export interface RequestInit {
 	size?: number;
 	highWaterMark?: number;
 	insecureHTTPParser?: boolean;
+	rejectUnauthorized?: boolean;
 }
 
 export interface ResponseInit {

--- a/src/request.js
+++ b/src/request.js
@@ -141,6 +141,9 @@ export default class Request extends Body {
 		// §5.4, Request constructor steps, step 16.
 		// Default is empty string per https://fetch.spec.whatwg.org/#concept-request-referrer-policy
 		this.referrerPolicy = init.referrerPolicy || input.referrerPolicy || '';
+
+		// Pass through to the node request api
+		this.rejectUnauthorized = init.rejectUnauthorized === undefined ? ( input.rejectUnauthorized === undefined ? true : input.rejectUnauthorized ) : init.rejectUnauthorized;
 	}
 
 	/** @returns {string} */
@@ -306,6 +309,7 @@ export const getNodeRequestOptions = request => {
 		method: request.method,
 		headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
 		insecureHTTPParser: request.insecureHTTPParser,
+		rejectUnauthorized: request.rejectUnauthorized,
 		agent
 	};
 

--- a/src/request.js
+++ b/src/request.js
@@ -137,13 +137,11 @@ export default class Request extends Body {
 		this.agent = init.agent || input.agent;
 		this.highWaterMark = init.highWaterMark || input.highWaterMark || 16384;
 		this.insecureHTTPParser = init.insecureHTTPParser || input.insecureHTTPParser || false;
+		this.rejectUnauthorized = init.rejectUnauthorized === undefined ? (input.rejectUnauthorized === undefined ? true : input.rejectUnauthorized) : init.rejectUnauthorized;
 
 		// §5.4, Request constructor steps, step 16.
 		// Default is empty string per https://fetch.spec.whatwg.org/#concept-request-referrer-policy
 		this.referrerPolicy = init.referrerPolicy || input.referrerPolicy || '';
-
-		// Pass through to the node request api
-		this.rejectUnauthorized = init.rejectUnauthorized === undefined ? ( input.rejectUnauthorized === undefined ? true : input.rejectUnauthorized ) : init.rejectUnauthorized;
 	}
 
 	/** @returns {string} */

--- a/test/request.js
+++ b/test/request.js
@@ -7,6 +7,7 @@ import FormData from 'form-data';
 import Blob from 'fetch-blob';
 
 import {Request} from '../src/index.js';
+import {getNodeRequestOptions} from '../src/request.js';
 import TestServer from './utils/server.js';
 
 const {expect} = chai;
@@ -83,6 +84,16 @@ describe('Request', () => {
 		expect(r2.follow).to.equal(2);
 		expect(r1.counter).to.equal(0);
 		expect(r2.counter).to.equal(0);
+	});
+
+	it('should pass through rejectUnauthorized from init', () => {
+		const request = new Request(`${base}hello`, {
+			rejectUnauthorized: false
+		});
+		expect(request.rejectUnauthorized).to.equal(false);
+
+		const requestOpts = getNodeRequestOptions(request);
+		expect(requestOpts.options.rejectUnauthorized).to.equal(false);
 	});
 
 	it('should override signal on derived Request instances', () => {
@@ -247,7 +258,8 @@ describe('Request', () => {
 			follow: 3,
 			compress: false,
 			agent,
-			signal
+			signal,
+			rejectUnauthorized: false
 		});
 		const cl = request.clone();
 		expect(cl.url).to.equal(url);
@@ -260,6 +272,7 @@ describe('Request', () => {
 		expect(cl.counter).to.equal(0);
 		expect(cl.agent).to.equal(agent);
 		expect(cl.signal).to.equal(signal);
+		expect(cl.rejectUnauthorized).to.equal(false);
 		// Clone body shouldn't be the same body
 		expect(cl.body).to.not.equal(body);
 		return Promise.all([cl.text(), request.text()]).then(results => {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Provide a way to connect to servers using self-signed certificates that works in vscode. 

## Changes
Added 'rejectUnauthorized' as an extended RequestInit option. 

## Additional information
See #1748 for context as to why this is necessary. 

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1748
