### PR TITLE
feat: optional get raw headers as string

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -65,7 +65,7 @@ export class Headers {
 	values(): IterableIterator<string>;
 
 	/** Node-fetch extension */
-	raw(): Record<string, string[]>;
+	raw(): Record<string, string[] | string>;
 }
 
 export interface RequestInit {

--- a/src/headers.js
+++ b/src/headers.js
@@ -197,11 +197,18 @@ export default class Headers extends URLSearchParams {
 	/**
 	 * Node-fetch non-spec method
 	 * returning all headers and their values as array
-	 * @returns {Record<string, string[]>}
+	 * @returns {Record<string, string[] | string>}
 	 */
-	raw() {
+	raw(asString = false) {
+		if (asString)  {
+
+		}
 		return [...this.keys()].reduce((result, key) => {
 			result[key] = this.getAll(key);
+
+			if (asString) {
+				result[key] = result[key].join(', ');
+			}
 			return result;
 		}, {});
 	}

--- a/test/headers.js
+++ b/test/headers.js
@@ -229,6 +229,16 @@ describe('Headers', () => {
 		expect(h3Raw.b).to.include('1');
 	});
 
+	it('should return headers as string if set to true', () => {
+		const headers = new Headers([
+			['a', '1'],
+			['b', '2'],
+			['a', '3']
+		]);
+
+		chai.assert.deepEqual(headers.raw(true), {a: '1, 3',  b: '2'})
+	})
+
 	it('should accept headers as an iterable of tuples', () => {
 		let headers;
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Most libraries expect raw headers to be a string instead of an array  so I added an optional argument which will return the raw headers as a string rather than a `string[]`.

## Changes

Added an optional argument to the `headers.raw()` function to return the header values as a string in case this is set to `true.

## Additional information

I could also create a second function like: `headers.rawAsString()` instead of adding an argument to the existing function.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->

Doesn't fix but is related to #783