### PR TITLE
fix: Remove the default connection close header (v2 branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,6 @@ Header              | Value
 ------------------- | --------------------------------------------------------
 `Accept-Encoding`   | `gzip,deflate` _(when `options.compress === true`)_
 `Accept`            | `*/*`
-`Connection`        | `close` _(when no `options.agent` is present)_
 `Content-Length`    | _(automatically calculated, if possible)_
 `Transfer-Encoding` | `chunked` _(when `req.body` is a stream)_
 `User-Agent`        | `node-fetch/1.0 (+https://github.com/bitinn/node-fetch)`
@@ -403,6 +402,8 @@ The `agent` option allows you to specify networking related options which are ou
 - Custom DNS Lookup
 
 See [`http.Agent`](https://nodejs.org/api/http.html#http_new_agent_options) for more information.
+
+If no agent is specified, the default agent provided by Node.js is used. Note that [this changed in Node.js 19](https://github.com/nodejs/node/blob/4267b92604ad78584244488e7f7508a690cb80d0/lib/_http_agent.js#L564) to have `keepalive` true by default. If you wish to enable `keepalive` in an earlier version of Node.js, you can override the agent as per the following code sample. 
 
 In addition, the `agent` option accepts a function that returns `http`(s)`.Agent` instance given current [URL](https://nodejs.org/api/url.html), this is useful during a redirection chain across HTTP and HTTPS protocol.
 

--- a/src/request.js
+++ b/src/request.js
@@ -258,10 +258,6 @@ export function getNodeRequestOptions(request) {
 		agent = agent(parsedURL);
 	}
 
-	if (!headers.has('Connection') && !agent) {
-		headers.set('Connection', 'close');
-	}
-
 	// HTTP-network fetch step 4.2
 	// chunked encoding is handled by Node.js
 


### PR DESCRIPTION
_This backports #1736 fixing #1735 to the 2.x branch. Reasoning for why this is important is [in this comment](https://github.com/node-fetch/node-fetch/pull/1736#issuecomment-1653306441)._

I believe this change is low-risk for applying against 2.x, for a few reasons:

* Note that the Connection Close isn't included if an agent is provided, which has seen no reported issues. This was likely a bug fix added because [in old node (eg v4) specifying an agent changed the default behaviour to keep-alive](https://nodejs.org/docs/latest-v4.x/api/http.html#http_http_request_options_callback), which triggered this bug.
* I don't believe sending a `Connection: Close` was ever needed. It appears to have always caused issues if trying to combine with keep-alive.
* Even on eg Node v4 docs for the default agent, it doesn't mention sending a `Connection: Close` header: https://nodejs.org/docs/latest-v4.x/api/http.html#http_http_globalagent. - there is a slim chance it might cause slight behaviour differences in terms of connection handling with some legacy web servers, but I believe it is unlikely to break anything and the risk is slim compared with the issue many people are encountering when not fixing the issue.

---

Instead, we rely on the underlying http implementation in Node.js to handle this, as per the documentation at
https://nodejs.org/api/http.html#new-agentoptions

This fixes #1735 and likely replaces #1473

The original change introducing this provided no clear motivation for the override, and the implementation has since been changed to disable this header when an agent is provided, so I think there is sufficient evidence that removing this is the correct behaviour. https://github.com/node-fetch/node-fetch/commit/af21ae6c1c964cd40e48e974af56ea2e1361304f https://github.com/node-fetch/node-fetch/commit/7f68577de44c7d1efe7009b212f7c54a0b4a709b

This commit is backported to the v2 branch from #1736 against v3.
