### PR TITLE
docs(README): when patching global context, patch TextDecoder and TextEncoder too

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,26 +141,28 @@ To use `fetch()` without importing it, you can patch the `global` object in node
 // fetch-polyfill.js
 import fetch, {
   Blob,
-  blobFrom,
-  blobFromSync,
   File,
-  fileFrom,
-  fileFromSync,
   FormData,
   Headers,
   Request,
   Response,
-} from 'node-fetch'
+} from 'node-fetch';
+import { TextDecoder, TextEncoder } from 'util';
 
 if (!globalThis.fetch) {
-  globalThis.fetch = fetch
-  globalThis.Headers = Headers
-  globalThis.Request = Request
-  globalThis.Response = Response
+  globalThis.fetch = fetch;
+  globalThis.Blob = Blob;
+  globalThis.File = File;
+  globalThis.FormData = FormData;
+  globalThis.Headers = Headers;
+  globalThis.Request = Request;
+  globalThis.Response = Response;
+  globalThis.TextDecoder = TextDecoder;
+  globalThis.TextEncoder = TextEncoder;
 }
 
 // index.js
-import './fetch-polyfill'
+import './fetch-polyfill';
 
 // ...
 ```


### PR DESCRIPTION
After following the README on patching the global context, node-fetch fails to me in jest jsdom environment on node v16.16.0 with following error:

```
TextDecoder is not defined

      Cause: ReferenceError: TextDecoder is not defined
      at Response.TextDecoder (node_modules/node-fetch/src/body.js:159:14)
      at call (node_modules/@babel/runtime/helpers/regeneratorRuntime.js:44:17)
      at Generator.tryCatch (node_modules/@babel/runtime/helpers/regeneratorRuntime.js:125:22)
      at Generator._invoke [as next] (node_modules/@babel/runtime/helpers/regeneratorRuntime.js:69:21)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
```

That's probably because node-fetch in https://github.com/node-fetch/node-fetch/blob/main/src/body.js#L159 refers to `TextDecoder` using a global reference, which doesn't exist in my environment.

## Changes

In recommended script in README that patches the global context, add `TextDecoder` and `TextEncoder` to the global context too.

I also removed a few unnecessary imports from it that weren't used at all.

## Additional information

- [x] I updated readme