### PR TITLE
support `AbortSignal.reason`

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -13,6 +13,7 @@ import {
 
 type AbortSignal = {
 	readonly aborted: boolean;
+	readonly reason: unknown;
 
 	addEventListener: (type: 'abort', listener: (this: AbortSignal) => void) => void;
 	removeEventListener: (type: 'abort', listener: (this: AbortSignal) => void) => void;
@@ -212,6 +213,7 @@ export class FetchError extends Error {
 export class AbortError extends Error {
 	type: string;
 	name: 'AbortError';
+	reason: DOMException | unknown;
 	[Symbol.toStringTag]: 'AbortError';
 }
 

--- a/src/errors/abort-error.js
+++ b/src/errors/abort-error.js
@@ -4,7 +4,9 @@ import {FetchBaseError} from './base.js';
  * AbortError interface for cancelled requests
  */
 export class AbortError extends FetchBaseError {
-	constructor(message, type = 'aborted') {
-		super(message, type);
+	constructor(message, reason) {
+		super(message, 'aborted');
+
+		this.reason = reason;
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default async function fetch(url, options_) {
 		let response = null;
 
 		const abort = () => {
-			const error = new AbortError('The operation was aborted.');
+			const error = new AbortError('The operation was aborted.', signal.reason);
 			reject(error);
 			if (request.body && request.body instanceof Stream.Readable) {
 				request.body.destroy(error);


### PR DESCRIPTION
In enviroments that implement it.

When an `AbortSignal#reason` has a value, i.e. in nodejs >= v17.2.0, it is added on the returned `AbortError`. `AbortError#reason` would be `undefined` otherwise.

Contrary to the specification, when `AbortController#abort` is called, with or without a reason, `fetch` _does not_ throw the `AbortSignal#reason`. This is to allow more fine grained error handling. Had the `reason` was thrown, the general information that an abort happened is lost and it becomes sole responsibility of the reason provider.

<!-- Thanks for contributing! -->

## Purpose

Allow detecting the _reason_ fetch was aborted.

## Changes

- Extend `AbortError` to have field `reason`. It's constructor takes this additional argument.
- The `AbortSignal#reason` is given when constructing `AbortError` instance. Could possibly be `undefined` in environments/libraries/polyfills that do not support it.

## Additional information

The actual value (even existence) of `AbortSignal#reason` is external to this library. We make no assumptions about it. We simply forward it.

This goes against #1519. There is no inherent reason to follow the specifications to the dot. `node-fetch` is for node, specifically, not the web. TBD.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1462
