### PR TITLE
Use `OutgoingHttpHeader` type from @types/node

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import {RequestOptions} from 'http';
+import {RequestOptions, OutgoingHttpHeader, OutgoingHttpHeaders} from 'http';
 import {FormData} from 'formdata-polyfill/esm.min.js';
 import {
 	Blob,
@@ -18,7 +18,7 @@ type AbortSignal = {
 	removeEventListener: (type: 'abort', listener: (this: AbortSignal) => void) => void;
 };
 
-export type HeadersInit = Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>;
+export type HeadersInit = Headers | OutgoingHttpHeaders | Iterable<readonly [string, OutgoingHttpHeader]> | Iterable<Iterable<OutgoingHttpHeader>>;
 
 export {
 	FormData,

--- a/@types/index.test-d.ts
+++ b/@types/index.test-d.ts
@@ -91,6 +91,8 @@ async function run() {
 		['b', '2'],
 		new Map([['a', null], ['3', null]]).keys()
 	]);
+	new Headers({'content-type': ['text/plain', 'application/json']});
+	new Headers({'content-length': 250});
 	/* eslint-enable no-new */
 
 	expectType<Response>(Response.redirect('https://google.com'));


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Fixing incompatibility issue between `HeadersInit` and `OutgoingHttpHeaders`.

## Changes
Use `OutgoingHttpHeader` type from @types/node

## Additional information
In fact users can pass array of header values and header vaue as number, but TS users can't.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
