### PR TITLE
fix: Redirect follows when using Request as input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ export default async function fetch(url, options_) {
 						}
 
 						// HTTP-redirect fetch step 9
-						if (response_.statusCode !== 303 && request.body && options_.body instanceof Stream.Readable) {
+						if (response_.statusCode !== 303 && requestOptions.body instanceof Stream.Readable) {
 							reject(new FetchError('Cannot follow redirect with body being a readable stream', 'unsupported-redirect'));
 							finalize();
 							return;


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Previously, there was a check in place that prevented a streaming request body from being redirected. However, this check assumed that the `fetch` function was invoked with the `fetch(url, initOptions)` overload, as opposed to the `fetch(request)` signature.

## Changes
This change makes the `instanceof` check against the (already cloned) body in the follow request's init options.

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1616
