### PR TITLE
chore: avoid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     },
     "homepage": "https://github.com/bitinn/node-fetch",
     "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "whatwg-url": "^14.0.0"
     },
     "peerDependencies": { 
         "encoding": "^0.1.0"


### PR DESCRIPTION
## Purpose

NodeJS 21 warns that the `punycode` is deprecated. The `whatwg-url@5.x` dependent by `node-fetch` depends on the deprecated `punycode`, therefore, it is better to upgrade the `whatwg-url` to the latest one 

https://github.com/jsdom/whatwg-url/issues/261

To reproduce it, try the below piece example

```js
const fetch = require('node-fetch') // 2.7.0

fetch('https://jsonplaceholder.typicode.com/todos/1')
      .then(response => response.json())
      .then(json => console.log(json))
```

```
➜  node-fetch git:(2.7) ✗ node x.js
(node:4461) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
{ userId: 1, id: 1, title: 'delectus aut autem', completed: false }
```

## Changes

Upgrade `whatwg-url` to the latest