### PR TITLE
refactor: allow exclude user agent using null value

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -274,8 +274,11 @@ export const getNodeRequestOptions = request => {
 	}
 
 	// HTTP-network-or-cache fetch step 2.11
+	// > If request's user-agent is null, excluding user-agent in request's header list
 	if (!headers.has('User-Agent')) {
 		headers.set('User-Agent', 'node-fetch');
+	} else if (headers.get('User-Agent') === 'null') {
+		headers.delete('User-Agent')
 	}
 
 	// HTTP-network-or-cache fetch step 2.15


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Some contexts, the default user agent of the request does not need to contain of header list, so use null value to exclude it from header list of the request

## Changes
Change logic of setting user-agent request's header

## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [x] I updated src/request.js

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1799