### PR TITLE
upgrade fetch-blob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        node: ["12.20.0", "14.13.1", "16.0.0"]
+        node: ["12.20.0", "14.13.1", "16.0.0", "18.18.2", "20.11.0", "21.5.0"]
         exclude:
           # On Windows, run tests with only the LTS environments.
           - os: windows-latest

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^4.0.0",
-    "fetch-blob": "^3.1.4",
+    "fetch-blob": "^4.0.0",
     "formdata-polyfill": "^4.0.10"
   },
   "tsd": {

--- a/src/body.js
+++ b/src/body.js
@@ -9,7 +9,7 @@ import Stream, {PassThrough} from 'node:stream';
 import {types, deprecate, promisify} from 'node:util';
 import {Buffer} from 'node:buffer';
 
-import Blob from 'fetch-blob';
+import { Blob } from 'fetch-blob';
 import {FormData, formDataToBlob} from 'formdata-polyfill/esm.min.js';
 
 import {FetchError} from './errors/fetch-error.js';

--- a/test/main.js
+++ b/test/main.js
@@ -2183,7 +2183,8 @@ describe('node-fetch', () => {
 		function lookupSpy(hostname, options, callback) {
 			families.push(options.family);
 
-			return lookup(hostname, {}, callback);
+			const cb = process.version.startsWith('v2') ? (err, address, family) => callback(err, [{address, family}]) : callback;
+			return lookup(hostname, {}, cb);
 		}
 
 		const agent = new http.Agent({lookup: lookupSpy, family});

--- a/test/request.js
+++ b/test/request.js
@@ -4,7 +4,7 @@ import http from 'node:http';
 import AbortController from 'abort-controller';
 import chai from 'chai';
 import FormData from 'form-data';
-import Blob from 'fetch-blob';
+import { Blob } from 'fetch-blob';
 
 import {Request} from '../src/index.js';
 import TestServer from './utils/server.js';

--- a/test/utils/server.js
+++ b/test/utils/server.js
@@ -410,7 +410,7 @@ export default class TestServer {
 
 		if (p === '/chunked/multiple-ending') {
 			res.socket.write('HTTP/1.1 200\r\nTransfer-Encoding: chunked\r\n\r\n');
-			res.socket.write('3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n');
+			res.socket.end('3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n');
 		}
 
 		if (p === '/error/json') {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
Upgrade version fetch-blob from 3.1.4 to 4.0.0
add to cicd version of node "18.18.2", "20.11.0", "21.5.0"
this update will reduce the size of dependencies from about 9.1MB to 0.4MB

## Changes
- changed package.json
- in test "supports supplying a famliy option to the agent" add custom callback since http.Agent->lookup changed from v20
- fixed for >v20 route /chunked/multiple-ending in custom server

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)
- [X] checked tests for versions 14.21.3, 16.20.2, 18.18.2, 20.11.0, 21.5.0

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
