### PR TITLE
chore: update fetch-blob version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "data-uri-to-buffer": "^4.0.0",
-    "fetch-blob": "^3.1.4",
+    "fetch-blob": "^4.0.0",
     "formdata-polyfill": "^4.0.10"
   },
   "tsd": {

--- a/src/body.js
+++ b/src/body.js
@@ -9,7 +9,7 @@ import Stream, {PassThrough} from 'node:stream';
 import {types, deprecate, promisify} from 'node:util';
 import {Buffer} from 'node:buffer';
 
-import Blob from 'fetch-blob';
+import {Blob} from 'fetch-blob';
 import {FormData, formDataToBlob} from 'formdata-polyfill/esm.min.js';
 
 import {FetchError} from './errors/fetch-error.js';

--- a/test/request.js
+++ b/test/request.js
@@ -4,7 +4,7 @@ import http from 'node:http';
 import AbortController from 'abort-controller';
 import chai from 'chai';
 import FormData from 'form-data';
-import Blob from 'fetch-blob';
+import {Blob} from 'fetch-blob';
 
 import {Request} from '../src/index.js';
 import TestServer from './utils/server.js';


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
In the `fetch-blob` package version 3.x, there was a dependency on the `web-streams-polyfill` package, which had a large size. In version `fetch-blob@4`, this dependency was dropped

## Changes


## Additional information
The API in the major version of the `fetch-blob` package remains unchanged

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
