### PR TITLE
Fix Referer header not being set for 'strict-origin' referrer policy.

### DIFF
--- a/src/utils/referrer.js
+++ b/src/utils/referrer.js
@@ -259,7 +259,7 @@ export function determineRequestsReferrer(request, {referrerURLCallback, referre
 			}
 
 			// 2. Return referrerOrigin.
-			return referrerOrigin.toString();
+			return referrerOrigin;
 
 		case 'strict-origin-when-cross-origin':
 			// 1. If the origin of referrerURL and the origin of request's current URL are the same, then

--- a/test/referrer.js
+++ b/test/referrer.js
@@ -38,6 +38,15 @@ describe('fetch() with referrer and referrerPolicy', () => {
 		});
 	});
 
+	it('should send request with a referrer when using strict-origin', () => {
+		return fetch(`${base}inspect`, {
+			referrer: base,
+			referrerPolicy: 'strict-origin'
+		}).then(res => res.json()).then(res => {
+			expect(res.headers.referer).to.equal(base);
+		});
+	});
+
 	it('should send request with referrerPolicy strict-origin-when-cross-origin by default', () => {
 		return Promise.all([
 			fetch(`${base}inspect`, {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose

Make sure the `Referer` header is correctly set when using the `strict-origin` referrer policy.

## Changes

There was a typo in the referrer computation code that returned a String instead of an URL for the `strict-origin` case.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [x] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
