### PR TITLE
Add abort reason as the AbortError cause

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,7 @@ export default async function fetch(url, options_) {
 
 		const abort = () => {
 			const error = new AbortError('The operation was aborted.');
+			error.cause = signal.reason;
 			reject(error);
 			if (request.body && request.body instanceof Stream.Readable) {
 				request.body.destroy(error);


### PR DESCRIPTION
To better capture the cause of the abort, we can attach the abort signal's [reason](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason) as the cause of the `AbortError` that we throw.

___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)