### PR TITLE
Adding support of the size property

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -139,6 +139,9 @@ export default class Headers extends URLSearchParams {
 							return new Set(URLSearchParams.prototype.keys.call(target)).keys();
 						};
 
+					case 'size': 
+						return [...target].length;
+
 					default:
 						return Reflect.get(target, p, receiver);
 				}


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
The proxy does not conform to the modern standard https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams which causes it to trigger runtime errors on modern Node.js

firebase-functions/logger uses node-fetch.

The issue causes innocent log statements in Google Cloud Functions to throw an exception terminating the function execution; pretty nasty stuff. 

This reproduced in the critical part of our code and may happen to others too.

```
import { google } from "googleapis";
import { debug } from "firebase-functions/logger";

  const androidpublisher = google.androidpublisher({
    version: "v3",
    auth: auth,
  });

  const result = androidpublisher.purchases.subscriptions.get({
    packageName: receipt.packageName,
    token: receipt.token,
    subscriptionId: receipt.productId,
  });

  debug(result); <- this fails with the callstack: 
{"severity":"DEBUG","message":"TypeError [ERR_INVALID_THIS]: Value of \"this\" must be of type URLSearchParams\n    at get size (node:internal/url:466:13)\n    at Reflect.get (<anonymous>)\n    at Object.get (file:///.../node_modules/googleapis-common/node_modules/node-fetch/src/headers.js:143:22)\n    at removeCircular 

  // actual business logic here
```

## Changes

Added the size property support

## Additional information
___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
___
<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #000
