### PR TITLE
fix crash on abort when body is not a stream

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -79,6 +79,15 @@ export default class Body {
 		};
 		this.size = size;
 
+		if (stream !== body) {
+			stream.on('error', error_ => {
+				const error = error_ instanceof FetchBaseError ?
+					error_ :
+					new FetchError(`Invalid response body while trying to fetch ${this.url}: ${error_.message}`, 'system', error_);
+				this[INTERNALS].error = error;
+			});
+		}
+
 		if (body instanceof Stream) {
 			body.on('error', error_ => {
 				const error = error_ instanceof FetchBaseError ?


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Purpose
This causes node-fetch to stop crashing node if you abort a request

## Changes


## Additional information


___

<!-- Mark the ones you have done and remove unnecessary ones. Add new tasks that fit (like TODOs). -->
- [ ] I updated readme
- [ ] I added unit test(s)

___

<!-- Add `- fix #_NUMBER_` line for every PR/Issue this PR solves. Do not comma separate them. -->
- fix #1801 
