### PR TITLE
docs: add note about built-in fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Current stable release (`3.x`) requires at least Node.js 12.20.0.
 npm install node-fetch
 ```
 
+> [!NOTE]  
+> The `fetch` API has been a built-in feature since Node.js v21, so you might not need `node-fetch`.
+
 ## Loading and configuring the module
 
 ### ES Modules (ESM)


### PR DESCRIPTION
The fetch API has been a stable feature since Node.js v21, and has been accessible with a flag since Node.js v18.

FIxes #1876, fixes #1864, fixes #1877, fixes #1873, fixes #1871, fixes #1869