### PR TITLE
docs: fix unbalanced parens in Response example and dead CHANGELOG links

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ http.createServer(async function (req, res) {
   const arrayBuffer = await new Response(req).arrayBuffer()
   const blob = await new Response(req, {
     headers: req.headers // So that `type` inherits `Content-Type`
-  }.blob()
+  }).blob()
 })
 ```
 

--- a/docs/v2-UPGRADE-GUIDE.md
+++ b/docs/v2-UPGRADE-GUIDE.md
@@ -106,4 +106,4 @@ information on Node.js' support lifetime.
 [gh-fetch]: https://github.com/github/fetch
 [chrome-headers]: https://crbug.com/645492
 [firefox-headers]: https://bugzilla.mozilla.org/show_bug.cgi?id=1278275
-[changelog]: CHANGELOG.md
+[changelog]: https://github.com/node-fetch/node-fetch/releases

--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -141,4 +141,4 @@ Since v3.x you no longer need to install `@types/node-fetch` package in order to
 [fetch-charset-detection-docs]: https://richienb.github.io/fetch-charset-detection/globals.html#convertbody
 [fetch-blob]: https://github.com/node-fetch/fetch-blob#readme
 [whatwg-nodejs-url]: https://nodejs.org/api/url.html#url_the_whatwg_url_api
-[changelog]: CHANGELOG.md
+[changelog]: https://github.com/node-fetch/node-fetch/releases


### PR DESCRIPTION
- The `body.blob()` example in the README closes the `new Response(...)` call in the wrong place (`}.blob()`), so the snippet throws a SyntaxError as written.
- Both upgrade guides link to `CHANGELOG.md`, which no longer exists in the repo — pointed them at GitHub Releases instead.

Found while running [docrot](https://github.com/getdocrot/docrot), a small checker that verifies docs examples and links against the code. Happy to adjust anything.